### PR TITLE
Auth Testing

### DIFF
--- a/Projecta-Backend/src/main/java/com/hackademics/Service/UserService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/Service/UserService.java
@@ -3,8 +3,10 @@ package com.hackademics.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.hackademics.model.Role;
 import com.hackademics.model.User;
@@ -29,17 +31,24 @@ public class UserService {
         return userRepository.findByEmail(email);
     }
 
+    public Optional<User> getUserById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+
     public User createUser(User user) { // Only used for testing. All real users should go through authentication. 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        if (user.getRole() == Role.ADMIN){
+        if (user.getRole() == Role.ADMIN) {
             user.setAdminId(generateNextAdminId());
         }
-        if (user.getRole() == Role.STUDENT){
+        if (user.getRole() == Role.STUDENT) {
             user.setStudentId(generateNextStudentId());
         }
         return userRepository.save(user);
     }
-
 
     public User updateUser(Long id, User updatedUser) {
         return userRepository.findById(id)
@@ -56,7 +65,15 @@ public class UserService {
         userRepository.deleteById(userId);
     }
 
-    // methods: 
+    // Utility methods
+
+    public void validateUniqueStudentId(Long studentId) {
+        Optional<User> existingUser = userRepository.findByStudentId(studentId);
+        if (existingUser.isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Student ID is already taken.");
+
+        }
+    }
 
     private Long generateNextStudentId() {
         Long maxStudentId = userRepository.findMaxStudentId();

--- a/Projecta-Backend/src/main/java/com/hackademics/config/SecurityConfig.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
- 
+
     }
 
     @Bean
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/**").permitAll() // Allow login/signup endpoints
                 .requestMatchers("/api/users/me").authenticated() // Secure /me endpoints
-                .anyRequest().permitAll() // Allow other requests 
+                .anyRequest().authenticated() // Allow other requests 
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/AuthController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/AuthController.java
@@ -1,6 +1,9 @@
 package com.hackademics.controller;
 
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,9 +17,13 @@ import com.hackademics.model.User;
 import com.hackademics.service.AuthenticationService;
 import com.hackademics.service.JwtService;
 
+import jakarta.validation.Valid;
+
 @RestController
 @RequestMapping("/auth")
+@Validated
 public class AuthController {
+
     private final JwtService jwtService;
     private final AuthenticationService authenticationService;
 
@@ -26,18 +33,23 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<User> register(@RequestBody SignUpDto signUpDto) {
-        User registeredUser;
-        if (signUpDto.getRole() == Role.ADMIN) {
-            registeredUser = authenticationService.signupAdmin(signUpDto);
-        } else {
-            registeredUser = authenticationService.signupStudent(signUpDto);
+    public ResponseEntity<?> register(@Valid @RequestBody SignUpDto signUpDto) {
+        try {
+            User registeredUser;
+            if (signUpDto.getRole() == Role.ADMIN) {
+                registeredUser = authenticationService.signupAdmin(signUpDto);
+            } else {
+                registeredUser = authenticationService.signupStudent(signUpDto);
+            }
+            return ResponseEntity.ok(registeredUser);
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Email is already in use");
         }
-        return ResponseEntity.ok(registeredUser);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> authenticate(@RequestBody LoginDto loginDto) {
+    public ResponseEntity<LoginResponse> authenticate(@Valid @RequestBody LoginDto loginDto) {
         User authenticatedUser = authenticationService.authenticate(loginDto);
 
         String jwtToken = jwtService.generateToken(authenticatedUser);

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/AuthController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/AuthController.java
@@ -45,6 +45,9 @@ public class AuthController {
         } catch (DataIntegrityViolationException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body("Email is already in use");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("An error occurred while registering the user");
         }
     }
 

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/UserController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/UserController.java
@@ -5,21 +5,25 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
-import com.hackademics.dto.SignUpDto;
+import com.hackademics.dto.UserUpdateDto;
 import com.hackademics.model.Role;
 import com.hackademics.model.User;
 import com.hackademics.service.UserService;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/users")
@@ -31,9 +35,19 @@ public class UserController {
         this.userService = userService;
     }
 
-    // Get all users (Admins or Students)
     @GetMapping
-    public ResponseEntity<List<User>> getUsersByRole(@RequestParam Role role) {
+    public ResponseEntity<List<User>> getUsersByRole(
+            @RequestParam Role role,
+            @AuthenticationPrincipal UserDetails currentUser) {
+
+        // Ensure the request is from an admin
+        User authenticatedUser = userService.getUserByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
+
+        if (authenticatedUser.getRole() != Role.ADMIN) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have permission to view user data.");
+        }
+
         return ResponseEntity.ok(userService.getUsersByRole(role));
     }
 
@@ -49,26 +63,70 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 
-    @PostMapping
-    public ResponseEntity<User> createUser(@RequestBody SignUpDto signUpDto) {
-        User user = new User();
-        user.setFirstName(signUpDto.getFirstName());
-        user.setLastName(signUpDto.getLastName());
-        user.setEmail(signUpDto.getEmail());
-        user.setPassword(signUpDto.getPassword());
-        user.setRole(signUpDto.getRole()); // Accepts both STUDENT and ADMIN
-
-        return ResponseEntity.ok(userService.createUser(user));
-    }
-
     @PutMapping("/{id}")
-    public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody User user) {
-        return ResponseEntity.ok(userService.updateUser(id, user));
+    public ResponseEntity<User> updateUser(
+            @PathVariable Long id,
+            @RequestBody @Valid UserUpdateDto userUpdateDto,
+            @AuthenticationPrincipal UserDetails currentUser) {
+
+        User userToUpdate = userService.getUserById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        User authenticatedUser = userService.getUserByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
+
+        boolean isAdmin = authenticatedUser.getRole() == Role.ADMIN;
+        boolean isSelfUpdate = authenticatedUser.getId().equals(userToUpdate.getId());
+
+        // Cannot update if user is not an admin or the update is not for the current user.
+        if (!isAdmin && !isSelfUpdate) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have permission to update this user.");
+        }
+
+        if (isAdmin) {
+            if (userUpdateDto.getFirstName() != null) {
+                userToUpdate.setFirstName(userUpdateDto.getFirstName());
+            }
+            if (userUpdateDto.getLastName() != null) {
+                userToUpdate.setLastName(userUpdateDto.getLastName());
+            }
+            if (userUpdateDto.getGender() != null) {
+                userToUpdate.setGender(userUpdateDto.getGender());
+            }
+
+            // Ensure Student ID is unique before updating
+            if (userUpdateDto.getStudentId() != null) {
+                userService.validateUniqueStudentId(userUpdateDto.getStudentId());
+                userToUpdate.setStudentId(userUpdateDto.getStudentId());
+            }
+        }
+        else if (userUpdateDto.getStudentId() != null || userUpdateDto.getFirstName() != null || userUpdateDto.getLastName() != null){
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have permission to update this information.");
+        } 
+
+        if (userUpdateDto.getEmail() != null) {
+            userToUpdate.setEmail(userUpdateDto.getEmail());
+        }
+
+        User updatedUser = userService.saveUser(userToUpdate);
+        return ResponseEntity.ok(updatedUser);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteUser(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails currentUser) {
+
+        // Ensure only admins can delete users
+        User authenticatedUser = userService.getUserByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
+
+        if (authenticatedUser.getRole() != Role.ADMIN) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only admins can delete users.");
+        }
+
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
+
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/LoginDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/LoginDto.java
@@ -3,33 +3,22 @@ package com.hackademics.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 public class LoginDto {
 
-
+    @Getter
+    @Setter
     @Email(message = "Invalid email format")
     @NotBlank(message = "Email is required")
     private String email;
 
+    @Getter
+    @Setter
     @NotBlank(message = "Password is required")
     @Size(min = 8, message = "Password must be at least 8 characters long")
     private String password;
 
-    // Getters and Setters
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
+    
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/SignUpDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/SignUpDto.java
@@ -5,6 +5,7 @@ import com.hackademics.model.Role;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,7 +36,7 @@ public class SignUpDto {
 
     @Getter
     @Setter
-    @NotBlank
+    @NotNull(message = "Role is required")
     @Enumerated
     private Role role;
 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/UserUpdateDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/UserUpdateDto.java
@@ -1,0 +1,17 @@
+package com.hackademics.dto;
+
+import com.hackademics.model.Gender;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserUpdateDto {
+    private String firstName;
+    private String lastName;
+    private Gender gender;
+    private String email;
+    private Long studentId; 
+}
+

--- a/Projecta-Backend/src/main/java/com/hackademics/model/Course.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/Course.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList; 
 import java.util.List;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,13 +28,13 @@ public class Course {
     @Getter
     @Setter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "course_id")
     private Long id;
 
     @Getter
     @Setter
     @ManyToOne
-    @JoinColumn(name = "admin_id", nullable = false)
+    @JoinColumn(name = "admin_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private User admin;
 
     @Getter
@@ -62,10 +65,12 @@ public class Course {
 
     @Getter
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private final List<Grade> grades = new ArrayList<>();
 
     @Getter
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private final List<Enrollment> enrollments = new ArrayList<>();
 
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/model/Subject.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/Subject.java
@@ -3,6 +3,9 @@ package com.hackademics.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,7 +25,6 @@ public class Subject {
     @Getter
     @Setter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "subject_id")
     private Long id;
 
     @Getter
@@ -32,5 +34,6 @@ public class Subject {
 
     @Getter
     @OneToMany(mappedBy = "subject", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Course> courses = new ArrayList<>(); 
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/model/User.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/User.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -82,14 +84,17 @@ public class User implements UserDetails {
     
     @Getter 
     @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Grade> grades = new ArrayList<>();
 
     @Getter
     @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Enrollment> enrollments = new ArrayList<>();
 
     @Getter
     @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<WaitlistEnrollment> waitListEnrollments = new ArrayList<>();
 
     // Admin specific properties
@@ -99,7 +104,7 @@ public class User implements UserDetails {
     private Long adminId;
 
     @Getter
-    @OneToMany(mappedBy = "admin", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "admin", cascade = CascadeType.PERSIST)
     private List<Course> courses = new ArrayList<>();
 
     @Override

--- a/Projecta-Backend/src/main/java/com/hackademics/model/Waitlist.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/Waitlist.java
@@ -3,6 +3,9 @@ package com.hackademics.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,7 +27,6 @@ public class Waitlist {
     @Getter
     @Setter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "waitlist_id")
     private Long id;
 
     @Getter
@@ -40,5 +42,6 @@ public class Waitlist {
 
     @Getter
     @OneToMany(mappedBy = "waitlist", cascade = CascadeType.ALL, orphanRemoval=true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private final List<WaitlistEnrollment> waitlistEnrollments = new ArrayList<>();
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/repository/UserRepository.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/repository/UserRepository.java
@@ -24,7 +24,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT MAX(u.adminId) FROM User u WHERE u.adminId IS NOT NULL")
     Long findMaxAdminId();
 
-    Optional<User> findByStudentId(Long studentId); // Im not sure if we will need these later, but think they might come in handy. 
+    Optional<User> findByStudentId(Long studentId); 
     Optional<User> findByAdminId(Long adminId);
 
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/UserService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/UserService.java
@@ -3,8 +3,10 @@ package com.hackademics.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.hackademics.model.Role;
 import com.hackademics.model.User;
@@ -29,17 +31,24 @@ public class UserService {
         return userRepository.findByEmail(email);
     }
 
+    public Optional<User> getUserById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+
     public User createUser(User user) { // Only used for testing. All real users should go through authentication. 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        if (user.getRole() == Role.ADMIN){
+        if (user.getRole() == Role.ADMIN) {
             user.setAdminId(generateNextAdminId());
         }
-        if (user.getRole() == Role.STUDENT){
+        if (user.getRole() == Role.STUDENT) {
             user.setStudentId(generateNextStudentId());
         }
         return userRepository.save(user);
     }
-
 
     public User updateUser(Long id, User updatedUser) {
         return userRepository.findById(id)
@@ -56,7 +65,15 @@ public class UserService {
         userRepository.deleteById(userId);
     }
 
-    // methods: 
+    // Utility methods
+
+    public void validateUniqueStudentId(Long studentId) {
+        Optional<User> existingUser = userRepository.findByStudentId(studentId);
+        if (existingUser.isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Student ID is already taken.");
+
+        }
+    }
 
     private Long generateNextStudentId() {
         Long maxStudentId = userRepository.findMaxStudentId();

--- a/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
@@ -8,13 +8,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackademics.dto.LoginDto;
 import com.hackademics.dto.SignUpDto;
 import com.hackademics.model.Role;
+import com.hackademics.model.User;
 import com.hackademics.repository.UserRepository;
 
 import jakarta.transaction.Transactional;
@@ -49,7 +52,7 @@ class AuthControllerTest {
         signUpDto.setFirstName("John");
         signUpDto.setLastName("Doe");
         signUpDto.setEmail("john@example.com");
-        signUpDto.setPassword("password123"); // Ensure password is set
+        signUpDto.setPassword("password123");
         signUpDto.setRole(Role.STUDENT);
 
         mockMvc.perform(post("/auth/signup")
@@ -60,4 +63,39 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.role").value("STUDENT"));
     }
 
+    @Test
+    void shouldLoginSuccessfully() throws Exception {
+        // Manually create and save a user since login requires an existing user
+        User user = new User();
+        user.setFirstName("John");
+        user.setLastName("Doe");
+        user.setEmail("john@example.com");
+        user.setPassword(passwordEncoder.encode("password123")); // Hash password
+        user.setRole(Role.STUDENT);
+        userRepository.save(user);
+
+        // Create login request
+        LoginDto loginDto = new LoginDto();
+        loginDto.setEmail("john@example.com");
+        loginDto.setPassword("password123");
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty()); // Ensure token is returned
+    }
+
+    @Test
+    void shouldDenyAccessToProtectedEndpointWithoutToken() throws Exception {
+        mockMvc.perform(get("/api/users/me")) // No token provided
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldDenyAccessToProtectedEndpointWithInvalidToken() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                .header("Authorization", "Bearer invalid_token"))
+                .andExpect(status().isUnauthorized());
+    }
 }

--- a/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
@@ -109,6 +109,59 @@ class AuthControllerTest {
     }
 
     @Test
+    void shouldFailRegistrationWithInvalidEmail() throws Exception {
+        SignUpDto signUpDto = new SignUpDto();
+        signUpDto.setFirstName("John");
+        signUpDto.setLastName("Doe");
+        signUpDto.setEmail("invalid-email"); // Missing @ and domain
+        signUpDto.setPassword("password123");
+        signUpDto.setRole(Role.STUDENT);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpDto)))
+                .andExpect(status().isBadRequest()); 
+    }
+
+    @Test
+    void shouldFailRegistrationWithDuplicateEmail() throws Exception {
+        User user = new User();
+        user.setFirstName("John");
+        user.setLastName("Doe");
+        user.setEmail("john@example.com");
+        user.setPassword(passwordEncoder.encode("password123")); // Hash password
+        user.setRole(Role.STUDENT);
+        userRepository.save(user);
+
+        SignUpDto signUpDto = new SignUpDto();
+        signUpDto.setFirstName("Jane");
+        signUpDto.setLastName("Doe");
+        signUpDto.setEmail("john@example.com"); // Duplicate email
+        signUpDto.setPassword("password456");
+        signUpDto.setRole(Role.STUDENT);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpDto)))
+                .andExpect(status().isBadRequest()); 
+    }
+
+    @Test
+    void shouldFailRegistrationWithNoRole() throws Exception {
+        SignUpDto signUpDto = new SignUpDto();
+        signUpDto.setFirstName("John");
+        signUpDto.setLastName("Doe");
+        signUpDto.setEmail("john@example.com");
+        signUpDto.setPassword("password123");
+        signUpDto.setRole(null); // Role is missing
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpDto)))
+                .andExpect(status().isBadRequest()); 
+    }
+
+    @Test
     void shouldDenyAccessToProtectedEndpointWithoutToken() throws Exception {
         mockMvc.perform(get("/api/users/me")) // No token provided
                 .andExpect(status().isUnauthorized());

--- a/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
@@ -1,0 +1,63 @@
+package com.hackademics.authTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackademics.dto.SignUpDto;
+import com.hackademics.model.Role;
+import com.hackademics.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        System.out.println("Before deleteAll, user count: " + userRepository.count());
+        userRepository.deleteAll();
+        System.out.println("After deleteAll, user count: " + userRepository.count());
+    }
+
+    @Test
+    void shouldRegisterNewUserSuccessfully() throws Exception {
+        SignUpDto signUpDto = new SignUpDto();
+        signUpDto.setFirstName("John");
+        signUpDto.setLastName("Doe");
+        signUpDto.setEmail("john@example.com");
+        signUpDto.setPassword("password123"); // Ensure password is set
+        signUpDto.setRole(Role.STUDENT);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("john@example.com"))
+                .andExpect(jsonPath("$.role").value("STUDENT"));
+    }
+
+}

--- a/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/authTest/AuthControllerTest.java
@@ -87,6 +87,28 @@ class AuthControllerTest {
     }
 
     @Test
+    void shouldLoginUnsuccessfully() throws Exception {
+        // Manually create and save a user since login requires an existing user
+        User user = new User();
+        user.setFirstName("John");
+        user.setLastName("Doe");
+        user.setEmail("john@example.com");
+        user.setPassword(passwordEncoder.encode("password123")); // Hash password
+        user.setRole(Role.STUDENT);
+        userRepository.save(user);
+
+        // Create login request
+        LoginDto loginDto = new LoginDto();
+        loginDto.setEmail("john@example.com");
+        loginDto.setPassword("password321"); // Incorrect password
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginDto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void shouldDenyAccessToProtectedEndpointWithoutToken() throws Exception {
         mockMvc.perform(get("/api/users/me")) // No token provided
                 .andExpect(status().isUnauthorized());

--- a/Projecta-Backend/src/test/java/com/hackademics/controllerTest/UserControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/controllerTest/UserControllerTest.java
@@ -1,0 +1,199 @@
+package com.hackademics.controllerTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackademics.dto.UserUpdateDto;
+import com.hackademics.model.Role;
+import com.hackademics.model.User;
+import com.hackademics.repository.UserRepository;
+import com.hackademics.service.JwtService;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private User student, admin, anotherStudent;
+
+    // Helper method
+    private String generateToken(User user) {
+        return jwtService.generateToken(user);
+    }
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll(); // Clean database before each test
+
+        admin = new User();
+        admin.setFirstName("Admin");
+        admin.setLastName("User");
+        admin.setEmail("admin@example.com");
+        admin.setPassword(passwordEncoder.encode("adminPass"));
+        admin.setRole(Role.ADMIN);
+        admin = userRepository.save(admin);
+
+        student = new User();
+        student.setFirstName("Student");
+        student.setLastName("User");
+        student.setEmail("student@example.com");
+        student.setPassword(passwordEncoder.encode("studentPass"));
+        student.setRole(Role.STUDENT);
+        student.setStudentId(123L);
+        student = userRepository.save(student);
+
+        anotherStudent = new User();
+        anotherStudent.setFirstName("Another");
+        anotherStudent.setLastName("Student");
+        anotherStudent.setEmail("anotherstudent@example.com");
+        anotherStudent.setPassword(passwordEncoder.encode("studentPass"));
+        anotherStudent.setRole(Role.STUDENT);
+        anotherStudent.setStudentId(456L);
+        anotherStudent = userRepository.save(anotherStudent);
+    }
+
+    @Test
+    void shouldAllowStudentToUpdateOwnEmail() throws Exception {
+        UserUpdateDto updateDto = new UserUpdateDto();
+        updateDto.setEmail("newemail@example.com");
+
+        mockMvc.perform(put("/api/users/" + student.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("newemail@example.com"));
+    }
+
+    @Test
+    void shouldNotAllowStudentToUpdateOwnName() throws Exception {
+        UserUpdateDto updateDto = new UserUpdateDto();
+        updateDto.setFirstName("NewName");
+
+        mockMvc.perform(put("/api/users/" + student.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isForbidden()); // Expecting 403 Forbidden
+    }
+
+    @Test
+    void shouldAllowAdminToUpdateStudentName() throws Exception {
+        UserUpdateDto updateDto = new UserUpdateDto();
+        updateDto.setFirstName("UpdatedName");
+
+        mockMvc.perform(put("/api/users/" + student.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("UpdatedName"));
+    }
+
+    @Test
+    void shouldAllowAdminToUpdateStudentIdIfAvailable() throws Exception {
+        UserUpdateDto updateDto = new UserUpdateDto();
+        updateDto.setStudentId(999L); // A new, available ID
+
+        mockMvc.perform(put("/api/users/" + student.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(999L));
+    }
+
+    @Test
+    void shouldNotAllowAdminToUpdateStudentIdIfTaken() throws Exception {
+        UserUpdateDto updateDto = new UserUpdateDto();
+        updateDto.setStudentId(456L); // Already taken by anotherStudent
+
+        mockMvc.perform(put("/api/users/" + student.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isConflict());
+
+    }
+
+    @Test
+    void shouldNotAllowStudentToUpdateAnotherStudentsEmail() throws Exception {
+        UserUpdateDto updateDto = new UserUpdateDto();
+        updateDto.setEmail("unauthorized@example.com");
+
+        mockMvc.perform(put("/api/users/" + anotherStudent.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDto))
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isForbidden()); // Expecting 403 Forbidden
+    }
+
+    @Test
+    void shouldAllowAdminToDeleteUser() throws Exception {
+        mockMvc.perform(delete("/api/users/" + student.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isNoContent()); // 204 No Content means successful delete
+    }
+
+    @Test
+    void shouldNotAllowStudentToDeleteUser() throws Exception {
+        mockMvc.perform(delete("/api/users/" + admin.getId())
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isForbidden()); // 403 Forbidden
+    }
+
+    @Test
+    void shouldAllowAdminToGetUsersByRole() throws Exception {
+        mockMvc.perform(get("/api/users")
+                .param("role", "STUDENT")
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2)); // Should return 2 students
+    }
+
+    @Test
+    void shouldNotAllowStudentToGetUsersByRole() throws Exception {
+        mockMvc.perform(get("/api/users")
+                .param("role", "STUDENT")
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isForbidden()); // 403 Forbidden
+    }
+
+    @Test
+    void shouldAllowUserToRetrieveTheirOwnInfo() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(student.getEmail()));
+    }
+
+}


### PR DESCRIPTION
## Authentication Testing 

This PR adds all necessary tests for Authentication processes. 
The testing is done in `AuthControllerTest`

### Tests

- Accept registration with a valid sign up request and returns a 200. 
- Accept login with a valid log in request. and returns a 200 
- Reject an invalid login request and properly returns a 403. 
- Rejects an invalid sign up attempt due to invalid email and returns a 400. 
- Rejects an invalid sign up attempt due to email already in-use and returns a 400. 
- Rejects an invalid sign up attempt due a required field left blank and returns a 400. 
- Rejects unauthorized access to the users/me endpoint and returns a 401. 
- Rejects invalid authorization when accessing users/me and returns a 401. 

### Effected Files: 
While implementing the tests it became evident some changes must be made to `JwtAuthenitcationFilter` and `AuthController`, as well as very minor changes to `SignUpDto` and `SecurityConfig`. 

### Notes: 

This PR also includes some minor fixes to the JPA schema to ensure proper cascading deletion.