### PR TITLE
Add Grade, Wailtist, and WaitlistEnrollment Controller Layers

### DIFF
--- a/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
@@ -1,5 +1,55 @@
 package com.hackademics.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hackademics.model.Grade;
+import com.hackademics.service.GradeService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/grades")
 public class GradeController {
 
+    @Autowired
+    private GradeService gradeService;
+
+    // Create a new grade
+    @PostMapping
+    public ResponseEntity<Grade> createGrade(@RequestBody Grade grade) {
+        Grade savedGrade = gradeService.saveGrade(grade);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedGrade);
+    }
+
+    // Get all grades
+    @GetMapping
+    public ResponseEntity<List<Grade>> getAllGrades() {
+        List<Grade> grades = gradeService.getAllGrades();
+        return ResponseEntity.ok(grades);
+    }
+
+    // Get a grade by its ID
+    @GetMapping("/{id}")
+    public ResponseEntity<Grade> getGradeById(@PathVariable Long id) {
+        Grade grade = gradeService.getGradeById(id);
+        return ResponseEntity.ok(grade);
+    }
+
+    // Update a grade
+    @PutMapping("/{id}")
+    public ResponseEntity<Grade> updateGrade(@PathVariable Long id, @RequestBody Grade grade) {
+        grade.setId(id); // Ensure the ID is set for the update
+        Grade updatedGrade = gradeService.updateGrade(grade);
+        return ResponseEntity.ok(updatedGrade);
+    }
+
+    // Delete a grade by its ID
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteGrade(@PathVariable Long id) {
+        gradeService.deleteGrade(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
@@ -1,0 +1,5 @@
+package com.hackademics.controller;
+
+public class GradeController {
+
+}

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
@@ -3,6 +3,8 @@ package com.hackademics.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import com.hackademics.model.Grade;
@@ -17,39 +19,81 @@ public class GradeController {
     @Autowired
     private GradeService gradeService;
 
-    // Create a new grade
+    // Create a new grade (Admin only)
     @PostMapping
-    public ResponseEntity<Grade> createGrade(@RequestBody Grade grade) {
+    public ResponseEntity<Grade> createGrade(@RequestBody Grade grade, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         Grade savedGrade = gradeService.saveGrade(grade);
         return ResponseEntity.status(HttpStatus.CREATED).body(savedGrade);
     }
 
-    // Get all grades
+    // Get all grades (Admin only)
     @GetMapping
-    public ResponseEntity<List<Grade>> getAllGrades() {
+    public ResponseEntity<List<Grade>> getAllGrades(@AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         List<Grade> grades = gradeService.getAllGrades();
         return ResponseEntity.ok(grades);
     }
 
-    // Get a grade by its ID
+    // Get a grade by its ID (Admin only)
     @GetMapping("/{id}")
-    public ResponseEntity<Grade> getGradeById(@PathVariable Long id) {
+    public ResponseEntity<Grade> getGradeById(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         Grade grade = gradeService.getGradeById(id);
         return ResponseEntity.ok(grade);
     }
 
-    // Update a grade
+    // Update a grade (Admin only)
     @PutMapping("/{id}")
-    public ResponseEntity<Grade> updateGrade(@PathVariable Long id, @RequestBody Grade grade) {
+    public ResponseEntity<Grade> updateGrade(@PathVariable Long id, @RequestBody Grade grade, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         grade.setId(id); // Ensure the ID is set for the update
         Grade updatedGrade = gradeService.updateGrade(grade);
         return ResponseEntity.ok(updatedGrade);
     }
 
-    // Delete a grade by its ID
+    // Delete a grade by its ID (Admin only)
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteGrade(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteGrade(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         gradeService.deleteGrade(id);
         return ResponseEntity.noContent().build();
+    }
+
+    // Get all grades for a specific user (Admin or student for their own grades)
+    @GetMapping("/student/{studentId}")
+    public ResponseEntity<List<Grade>> getGradesByStudentId(@PathVariable Long studentId, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin or the student themselves
+        if (!isAdmin(currentUser) && !isStudent(currentUser, studentId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        List<Grade> grades = gradeService.getGradesByStudentId(studentId, currentUser);
+        return ResponseEntity.ok(grades);
+    }
+
+    // Helper method to check if the current user is an admin
+    private boolean isAdmin(UserDetails currentUser) {
+        return currentUser.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+    }
+
+    // Helper method to check if the current user is the student themselves
+    private boolean isStudent(UserDetails currentUser, Long studentId) {
+        return currentUser.getUsername().equals(studentId.toString());
     }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
@@ -1,5 +1,55 @@
 package com.hackademics.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hackademics.model.Waitlist;
+import com.hackademics.service.WaitlistService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/waitlists")
 public class WaitlistController {
 
+    @Autowired
+    private WaitlistService waitlistService;
+
+    // Create a new waitlist
+    @PostMapping
+    public ResponseEntity<Waitlist> createWaitlist(@RequestBody Waitlist waitlist) {
+        Waitlist savedWaitlist = waitlistService.saveWaitlist(waitlist);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedWaitlist);
+    }
+
+    // Get all waitlists
+    @GetMapping
+    public ResponseEntity<List<Waitlist>> getAllWaitlists() {
+        List<Waitlist> waitlists = waitlistService.getAllWaitlists();
+        return ResponseEntity.ok(waitlists);
+    }
+
+    // Get a waitlist by its ID
+    @GetMapping("/{id}")
+    public ResponseEntity<Waitlist> getWaitlistById(@PathVariable Long id) {
+        Waitlist waitlist = waitlistService.getWaitlistById(id);
+        return ResponseEntity.ok(waitlist);
+    }
+
+    // Update a waitlist
+    @PutMapping("/{id}")
+    public ResponseEntity<Waitlist> updateWaitlist(@PathVariable Long id, @RequestBody Waitlist waitlist) {
+        waitlist.setId(id); // Ensure the ID is set for the update
+        Waitlist updatedWaitlist = waitlistService.updateWaitlist(waitlist);
+        return ResponseEntity.ok(updatedWaitlist);
+    }
+
+    // Delete a waitlist by its ID
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteWaitlist(@PathVariable Long id) {
+        waitlistService.deleteWaitlist(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
@@ -3,6 +3,8 @@ package com.hackademics.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import com.hackademics.model.Waitlist;
@@ -17,39 +19,65 @@ public class WaitlistController {
     @Autowired
     private WaitlistService waitlistService;
 
-    // Create a new waitlist
+    // Create a new waitlist (Admin only)
     @PostMapping
-    public ResponseEntity<Waitlist> createWaitlist(@RequestBody Waitlist waitlist) {
+    public ResponseEntity<Waitlist> createWaitlist(@RequestBody Waitlist waitlist, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         Waitlist savedWaitlist = waitlistService.saveWaitlist(waitlist);
         return ResponseEntity.status(HttpStatus.CREATED).body(savedWaitlist);
     }
 
-    // Get all waitlists
+    // Get all waitlists (Admin only)
     @GetMapping
-    public ResponseEntity<List<Waitlist>> getAllWaitlists() {
+    public ResponseEntity<List<Waitlist>> getAllWaitlists(@AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         List<Waitlist> waitlists = waitlistService.getAllWaitlists();
         return ResponseEntity.ok(waitlists);
     }
 
-    // Get a waitlist by its ID
+    // Get a waitlist by its ID (Admin only)
     @GetMapping("/{id}")
-    public ResponseEntity<Waitlist> getWaitlistById(@PathVariable Long id) {
+    public ResponseEntity<Waitlist> getWaitlistById(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         Waitlist waitlist = waitlistService.getWaitlistById(id);
         return ResponseEntity.ok(waitlist);
     }
 
-    // Update a waitlist
+    // Update a waitlist (Admin only)
     @PutMapping("/{id}")
-    public ResponseEntity<Waitlist> updateWaitlist(@PathVariable Long id, @RequestBody Waitlist waitlist) {
+    public ResponseEntity<Waitlist> updateWaitlist(@PathVariable Long id, @RequestBody Waitlist waitlist, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         waitlist.setId(id); // Ensure the ID is set for the update
         Waitlist updatedWaitlist = waitlistService.updateWaitlist(waitlist);
         return ResponseEntity.ok(updatedWaitlist);
     }
 
-    // Delete a waitlist by its ID
+    // Delete a waitlist by its ID (Admin only)
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteWaitlist(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteWaitlist(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         waitlistService.deleteWaitlist(id);
         return ResponseEntity.noContent().build();
+    }
+
+    // Helper method to check if the current user is an admin
+    private boolean isAdmin(UserDetails currentUser) {
+        return currentUser.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
     }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
@@ -1,0 +1,5 @@
+package com.hackademics.controller;
+
+public class WaitlistController {
+
+}

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistController.java
@@ -22,7 +22,6 @@ public class WaitlistController {
     // Create a new waitlist (Admin only)
     @PostMapping
     public ResponseEntity<Waitlist> createWaitlist(@RequestBody Waitlist waitlist, @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -33,7 +32,6 @@ public class WaitlistController {
     // Get all waitlists (Admin only)
     @GetMapping
     public ResponseEntity<List<Waitlist>> getAllWaitlists(@AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -44,7 +42,6 @@ public class WaitlistController {
     // Get a waitlist by its ID (Admin only)
     @GetMapping("/{id}")
     public ResponseEntity<Waitlist> getWaitlistById(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -55,7 +52,6 @@ public class WaitlistController {
     // Update a waitlist (Admin only)
     @PutMapping("/{id}")
     public ResponseEntity<Waitlist> updateWaitlist(@PathVariable Long id, @RequestBody Waitlist waitlist, @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -67,7 +63,6 @@ public class WaitlistController {
     // Delete a waitlist by its ID (Admin only)
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteWaitlist(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
@@ -26,50 +26,54 @@ public class WaitlistEnrollmentController {
     public ResponseEntity<WaitlistEnrollment> createWaitlistEnrollment(
             @RequestBody WaitlistEnrollment waitlistEnrollment,
             @AuthenticationPrincipal UserDetails currentUser) {
+
+        // Check if the waitlist is at capacity
+        if (waitlistEnrollment.getWaitlist().getCurrentCapacity() >= waitlistEnrollment.getWaitlist().getMaxCapacity()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null); // Waitlist is full
+        }
+
+        // Check user permissions
         if (!isAdmin(currentUser) && !isStudent(currentUser, waitlistEnrollment.getStudent().getId())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
+
+        // Save enrollment
         WaitlistEnrollment savedEnrollment = waitlistEnrollmentService.saveWaitlistEnrollment(waitlistEnrollment);
-        return ResponseEntity.status(HttpStatus.CREATED).body(savedEnrollment);
-    }
 
-    // Get all waitlist enrollments (Admin only)
-    @GetMapping
-    public ResponseEntity<List<WaitlistEnrollment>> getAllWaitlistEnrollments(@AuthenticationPrincipal UserDetails currentUser) {
-        if (!isAdmin(currentUser)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        List<WaitlistEnrollment> enrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
-        return ResponseEntity.ok(enrollments);
-    }
+       // Add the new enrollment to the waitlist's enrollments (this will update the current capacity)
+       waitlistEnrollment.getWaitlist().getWaitlistEnrollments().add(savedEnrollment);
 
-    // Get a waitlist enrollment by its ID (Admin only)
-    @GetMapping("/{id}")
-    public ResponseEntity<WaitlistEnrollment> getWaitlistEnrollmentById(
-            @PathVariable Long id,
-            @AuthenticationPrincipal UserDetails currentUser) {
-        if (!isAdmin(currentUser)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
-        return ResponseEntity.ok(enrollment);
-    }
+       // Update the waitlist with the new enrollment
+       waitlistEnrollmentService.updateWaitlistEnrollment(waitlistEnrollment.getWaitlist());
+
+       return ResponseEntity.status(HttpStatus.CREATED).body(savedEnrollment);
+   }
 
     // Delete a waitlist enrollment by its ID (Admin for all students, student for themselves)
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteWaitlistEnrollment(
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails currentUser) {
+
         WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
         if (enrollment == null) {
             return ResponseEntity.notFound().build();
         }
 
+        // Check user permissions
         if (!isAdmin(currentUser) && !isStudent(currentUser, enrollment.getStudent().getId())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
+        // Remove the enrollment from the waitlist
+        enrollment.getWaitlist().getWaitlistEnrollments().remove(enrollment);
+
+        // Update the waitlist with the new enrollment list (this will update the current capacity)
+        waitlistEnrollmentService.updateWaitlistEnrollment(enrollment.getWaitlist());
+
+        // Delete the waitlist enrollment
         waitlistEnrollmentService.deleteWaitlistEnrollment(id);
+
         return ResponseEntity.noContent().build();
     }
 
@@ -78,6 +82,7 @@ public class WaitlistEnrollmentController {
     public ResponseEntity<List<WaitlistEnrollment>> getWaitlistEnrollmentsByCourseId(
             @PathVariable Long courseId,
             @AuthenticationPrincipal UserDetails currentUser) {
+
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -101,3 +106,4 @@ public class WaitlistEnrollmentController {
         return currentUser.getUsername().equals(studentId.toString());
     }
 }
+

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
@@ -1,0 +1,5 @@
+package com.hackademics.controller;
+
+public class WaitlistEnrollmentController {
+
+}

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import com.hackademics.model.WaitlistEnrollment;
+import com.hackademics.model.User;
 import com.hackademics.service.WaitlistEnrollmentService;
 
 import java.util.List;
@@ -25,7 +26,6 @@ public class WaitlistEnrollmentController {
     public ResponseEntity<WaitlistEnrollment> createWaitlistEnrollment(
             @RequestBody WaitlistEnrollment waitlistEnrollment,
             @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin or the student themselves
         if (!isAdmin(currentUser) && !isStudent(currentUser, waitlistEnrollment.getStudent().getId())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -36,7 +36,6 @@ public class WaitlistEnrollmentController {
     // Get all waitlist enrollments (Admin only)
     @GetMapping
     public ResponseEntity<List<WaitlistEnrollment>> getAllWaitlistEnrollments(@AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -49,7 +48,6 @@ public class WaitlistEnrollmentController {
     public ResponseEntity<WaitlistEnrollment> getWaitlistEnrollmentById(
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -62,13 +60,11 @@ public class WaitlistEnrollmentController {
     public ResponseEntity<Void> deleteWaitlistEnrollment(
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails currentUser) {
-        // Fetch the enrollment to check the student ID
         WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
         if (enrollment == null) {
             return ResponseEntity.notFound().build();
         }
 
-        // Check if the current user is an admin or the student themselves
         if (!isAdmin(currentUser) && !isStudent(currentUser, enrollment.getStudent().getId())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
@@ -82,12 +78,10 @@ public class WaitlistEnrollmentController {
     public ResponseEntity<List<WaitlistEnrollment>> getWaitlistEnrollmentsByCourseId(
             @PathVariable Long courseId,
             @AuthenticationPrincipal UserDetails currentUser) {
-        // Check if the current user is an admin
         if (!isAdmin(currentUser)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        // Fetch all enrollments and filter by course ID
         List<WaitlistEnrollment> allEnrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
         List<WaitlistEnrollment> courseEnrollments = allEnrollments.stream()
                 .filter(enrollment -> enrollment.getWaitlist().getCourse().getId().equals(courseId))

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
@@ -3,12 +3,15 @@ package com.hackademics.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import com.hackademics.model.WaitlistEnrollment;
 import com.hackademics.service.WaitlistEnrollmentService;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/waitlist-enrollments")
@@ -17,39 +20,90 @@ public class WaitlistEnrollmentController {
     @Autowired
     private WaitlistEnrollmentService waitlistEnrollmentService;
 
-    // Create a new waitlist enrollment
+    // Create a new waitlist enrollment (Admin for any student, student for themselves)
     @PostMapping
-    public ResponseEntity<WaitlistEnrollment> createWaitlistEnrollment(@RequestBody WaitlistEnrollment waitlistEnrollment) {
+    public ResponseEntity<WaitlistEnrollment> createWaitlistEnrollment(
+            @RequestBody WaitlistEnrollment waitlistEnrollment,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin or the student themselves
+        if (!isAdmin(currentUser) && !isStudent(currentUser, waitlistEnrollment.getStudent().getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         WaitlistEnrollment savedEnrollment = waitlistEnrollmentService.saveWaitlistEnrollment(waitlistEnrollment);
         return ResponseEntity.status(HttpStatus.CREATED).body(savedEnrollment);
     }
 
-    // Get all waitlist enrollments
+    // Get all waitlist enrollments (Admin only)
     @GetMapping
-    public ResponseEntity<List<WaitlistEnrollment>> getAllWaitlistEnrollments() {
+    public ResponseEntity<List<WaitlistEnrollment>> getAllWaitlistEnrollments(@AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         List<WaitlistEnrollment> enrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
         return ResponseEntity.ok(enrollments);
     }
 
-    // Get a waitlist enrollment by its ID
+    // Get a waitlist enrollment by its ID (Admin only)
     @GetMapping("/{id}")
-    public ResponseEntity<WaitlistEnrollment> getWaitlistEnrollmentById(@PathVariable Long id) {
+    public ResponseEntity<WaitlistEnrollment> getWaitlistEnrollmentById(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
         return ResponseEntity.ok(enrollment);
     }
 
-    // Update a waitlist enrollment
-    @PutMapping("/{id}")
-    public ResponseEntity<WaitlistEnrollment> updateWaitlistEnrollment(@PathVariable Long id, @RequestBody WaitlistEnrollment waitlistEnrollment) {
-        waitlistEnrollment.setId(id); // Ensure the ID is set for the update
-        WaitlistEnrollment updatedEnrollment = waitlistEnrollmentService.updateWaitlistEnrollment(waitlistEnrollment);
-        return ResponseEntity.ok(updatedEnrollment);
-    }
-
-    // Delete a waitlist enrollment by its ID
+    // Delete a waitlist enrollment by its ID (Admin for all students, student for themselves)
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteWaitlistEnrollment(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteWaitlistEnrollment(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        // Fetch the enrollment to check the student ID
+        WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
+        if (enrollment == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // Check if the current user is an admin or the student themselves
+        if (!isAdmin(currentUser) && !isStudent(currentUser, enrollment.getStudent().getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         waitlistEnrollmentService.deleteWaitlistEnrollment(id);
         return ResponseEntity.noContent().build();
+    }
+
+    // Get all waitlist enrollments for a specific course (Admin only)
+    @GetMapping("/course/{courseId}")
+    public ResponseEntity<List<WaitlistEnrollment>> getWaitlistEnrollmentsByCourseId(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        // Check if the current user is an admin
+        if (!isAdmin(currentUser)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        // Fetch all enrollments and filter by course ID
+        List<WaitlistEnrollment> allEnrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
+        List<WaitlistEnrollment> courseEnrollments = allEnrollments.stream()
+                .filter(enrollment -> enrollment.getWaitlist().getCourse().getId().equals(courseId))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(courseEnrollments);
+    }
+
+    // Helper method to check if the current user is an admin
+    private boolean isAdmin(UserDetails currentUser) {
+        return currentUser.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+    }
+
+    // Helper method to check if the current user is the student themselves
+    private boolean isStudent(UserDetails currentUser, Long studentId) {
+        return currentUser.getUsername().equals(studentId.toString());
     }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
@@ -1,5 +1,55 @@
 package com.hackademics.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hackademics.model.WaitlistEnrollment;
+import com.hackademics.service.WaitlistEnrollmentService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/waitlist-enrollments")
 public class WaitlistEnrollmentController {
 
+    @Autowired
+    private WaitlistEnrollmentService waitlistEnrollmentService;
+
+    // Create a new waitlist enrollment
+    @PostMapping
+    public ResponseEntity<WaitlistEnrollment> createWaitlistEnrollment(@RequestBody WaitlistEnrollment waitlistEnrollment) {
+        WaitlistEnrollment savedEnrollment = waitlistEnrollmentService.saveWaitlistEnrollment(waitlistEnrollment);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedEnrollment);
+    }
+
+    // Get all waitlist enrollments
+    @GetMapping
+    public ResponseEntity<List<WaitlistEnrollment>> getAllWaitlistEnrollments() {
+        List<WaitlistEnrollment> enrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
+        return ResponseEntity.ok(enrollments);
+    }
+
+    // Get a waitlist enrollment by its ID
+    @GetMapping("/{id}")
+    public ResponseEntity<WaitlistEnrollment> getWaitlistEnrollmentById(@PathVariable Long id) {
+        WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
+        return ResponseEntity.ok(enrollment);
+    }
+
+    // Update a waitlist enrollment
+    @PutMapping("/{id}")
+    public ResponseEntity<WaitlistEnrollment> updateWaitlistEnrollment(@PathVariable Long id, @RequestBody WaitlistEnrollment waitlistEnrollment) {
+        waitlistEnrollment.setId(id); // Ensure the ID is set for the update
+        WaitlistEnrollment updatedEnrollment = waitlistEnrollmentService.updateWaitlistEnrollment(waitlistEnrollment);
+        return ResponseEntity.ok(updatedEnrollment);
+    }
+
+    // Delete a waitlist enrollment by its ID
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteWaitlistEnrollment(@PathVariable Long id) {
+        waitlistEnrollmentService.deleteWaitlistEnrollment(id);
+        return ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
This PR adds controller layers for Grade, Waitlist, and WaitlistEnrollment entities. Each controller provides CRUD functionality with RESTful endpoints and integrates with their respective services. JWT-based authentication is implemented for secure access.

Changes:

Added GradeController, WaitlistController, and WaitlistEnrollmentController.

Implemented CRUD endpoints (POST, GET, PUT, DELETE).

Integrated services using @Autowired.