### PR TITLE
Grades, Waitlist, Waitlist Enrollment 

### DIFF
--- a/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/GradeController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.hackademics.dto.GradeDto;
 import com.hackademics.dto.GradeUpdateDto;
-import com.hackademics.model.Grade;
+import com.hackademics.dto.GradeResponseDto;
 import com.hackademics.service.GradeService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,13 +42,13 @@ public class GradeController {
     @Operation(summary = "Create grade", description = "Creates a new grade")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successfully created grade",
-                    content = @Content(schema = @Schema(implementation = Grade.class))),
+                    content = @Content(schema = @Schema(implementation = GradeResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "Invalid input data"),
         @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
         @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions")
     })
     @PostMapping
-    public ResponseEntity<Grade> createGrade(
+    public ResponseEntity<GradeResponseDto> createGrade(
             @Parameter(description = "Grade data", required = true) 
             @Valid @RequestBody GradeDto gradeDto,
             @AuthenticationPrincipal UserDetails currentUser) {
@@ -58,25 +58,25 @@ public class GradeController {
     @Operation(summary = "Get all grades", description = "Retrieves all grades (admin only)")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successfully retrieved grades",
-                    content = @Content(schema = @Schema(implementation = Grade.class))),
+                    content = @Content(schema = @Schema(implementation = GradeResponseDto.class))),
         @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
         @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions")
     })
     @GetMapping
-    public ResponseEntity<List<Grade>> getAllGrades(@AuthenticationPrincipal UserDetails currentUser) {
+    public ResponseEntity<List<GradeResponseDto>> getAllGrades(@AuthenticationPrincipal UserDetails currentUser) {
         return ResponseEntity.ok(gradeService.getAllGrades(currentUser));
     }
 
     @Operation(summary = "Get grade by ID", description = "Retrieves a specific grade by its ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successfully retrieved grade",
-                    content = @Content(schema = @Schema(implementation = Grade.class))),
+                    content = @Content(schema = @Schema(implementation = GradeResponseDto.class))),
         @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
         @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions"),
         @ApiResponse(responseCode = "404", description = "Grade not found")
     })
     @GetMapping("/{id}")
-    public ResponseEntity<Grade> getGradeById(
+    public ResponseEntity<GradeResponseDto> getGradeById(
             @Parameter(description = "ID of the grade", required = true) 
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails currentUser) {
@@ -86,14 +86,14 @@ public class GradeController {
     @Operation(summary = "Update grade", description = "Updates an existing grade")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successfully updated grade",
-                    content = @Content(schema = @Schema(implementation = Grade.class))),
+                    content = @Content(schema = @Schema(implementation = GradeResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "Invalid input data"),
         @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
         @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions"),
         @ApiResponse(responseCode = "404", description = "Grade not found")
     })
     @PutMapping("/{id}")
-    public ResponseEntity<Grade> updateGrade(
+    public ResponseEntity<GradeResponseDto> updateGrade(
             @Parameter(description = "ID of the grade to update", required = true) 
             @PathVariable Long id,
             @Parameter(description = "Updated grade data", required = true) 
@@ -121,12 +121,12 @@ public class GradeController {
     @Operation(summary = "Get student grades", description = "Retrieves all grades for a specific student")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successfully retrieved student grades",
-                    content = @Content(schema = @Schema(implementation = Grade.class))),
+                    content = @Content(schema = @Schema(implementation = GradeResponseDto.class))),
         @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
         @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions")
     })
     @GetMapping("/student/{studentId}")
-    public ResponseEntity<List<Grade>> getGradesByStudentId(
+    public ResponseEntity<List<GradeResponseDto>> getGradesByStudentId(
             @Parameter(description = "ID of the student", required = true) 
             @PathVariable Long studentId,
             @AuthenticationPrincipal UserDetails currentUser) {

--- a/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/controller/WaitlistEnrollmentController.java
@@ -1,121 +1,93 @@
 package com.hackademics.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import com.hackademics.model.Waitlist;
-import com.hackademics.model.WaitlistEnrollment;
-import com.hackademics.repository.WaitlistRepository;
+import com.hackademics.dto.WaitlistEnrollmentDto;
+import com.hackademics.dto.WaitlistEnrollmentResponseDto;
 import com.hackademics.service.WaitlistEnrollmentService;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/waitlist-enrollments")
+@Tag(name = "Waitlist Enrollments", description = "APIs for managing waitlist enrollments")
+@SecurityRequirement(name = "bearer-jwt")
 public class WaitlistEnrollmentController {
 
     @Autowired
     private WaitlistEnrollmentService waitlistEnrollmentService;
-    
-    @Autowired
-    private WaitlistRepository waitlistRepository;
 
+    @Operation(summary = "Create waitlist enrollment", description = "Creates a new waitlist enrollment")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Successfully created waitlist enrollment",
+                    content = @Content(schema = @Schema(implementation = WaitlistEnrollmentResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input data"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions")
+    })
     @PostMapping
-    public ResponseEntity<WaitlistEnrollment> createWaitlistEnrollment(
-            @RequestBody WaitlistEnrollment waitlistEnrollment,
+    public ResponseEntity<WaitlistEnrollmentResponseDto> createWaitlistEnrollment(
+            @Parameter(description = "Waitlist enrollment data", required = true) 
+            @Valid @RequestBody WaitlistEnrollmentDto waitlistEnrollmentDto,
             @AuthenticationPrincipal UserDetails currentUser) {
-        
-        // Authorization check
-        if (!isAdmin(currentUser) && !isStudent(currentUser, waitlistEnrollment.getStudent().getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        
-        // Get the waitlist
-        Waitlist waitlist = waitlistRepository.findById(waitlistEnrollment.getWaitlist().getId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Waitlist not found"));
-        
-        // Count current enrollments by filtering all enrollments
-        List<WaitlistEnrollment> allEnrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
-        long currentEnrollments = allEnrollments.stream()
-                .filter(e -> e.getWaitlist().getId().equals(waitlist.getId()))
-                .count();
-        
-        // Check capacity against waitlist limit
-        if (currentEnrollments >= waitlist.getWaitlistLimit()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
-                "Waitlist is at capacity. Cannot add more enrollments.");
-        }
-        
-        // Set position and create
-        waitlistEnrollment.setWaitlistPosition((int)currentEnrollments + 1);
-        WaitlistEnrollment createdEnrollment = waitlistEnrollmentService.saveWaitlistEnrollment(waitlistEnrollment);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdEnrollment);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(waitlistEnrollmentService.saveWaitlistEnrollment(waitlistEnrollmentDto, currentUser));
     }
 
-    @GetMapping
-    public ResponseEntity<List<WaitlistEnrollment>> getAllWaitlistEnrollments(
-            @AuthenticationPrincipal UserDetails currentUser) {
-        if (!isAdmin(currentUser)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        return ResponseEntity.ok(waitlistEnrollmentService.getAllWaitlistEnrollments());
-    }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<WaitlistEnrollment> getWaitlistEnrollmentById(
-            @PathVariable Long id,
-            @AuthenticationPrincipal UserDetails currentUser) {
-        if (!isAdmin(currentUser)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        return ResponseEntity.ok(waitlistEnrollmentService.getWaitlistEnrollmentById(id));
-    }
-
+    @Operation(summary = "Delete waitlist enrollment", description = "Deletes a waitlist enrollment")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "Successfully deleted waitlist enrollment"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions"),
+        @ApiResponse(responseCode = "404", description = "Waitlist enrollment not found")
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteWaitlistEnrollment(
+            @Parameter(description = "ID of the waitlist enrollment to delete", required = true) 
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails currentUser) {
-        
-        WaitlistEnrollment enrollment = waitlistEnrollmentService.getWaitlistEnrollmentById(id);
-        
-        // Authorization check
-        if (!isAdmin(currentUser) && !isStudent(currentUser, enrollment.getStudent().getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        
-        // Delete the enrollment
-        waitlistEnrollmentService.deleteWaitlistEnrollment(id);
-        
-        // Update positions of remaining enrollments
-        updateWaitlistPositions(enrollment.getWaitlist().getId());
-        
+        waitlistEnrollmentService.deleteWaitlistEnrollment(id, currentUser);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/course/{courseId}")
-    public ResponseEntity<List<WaitlistEnrollment>> getWaitlistEnrollmentsByCourseId(
-            @PathVariable Long courseId,
+    @Operation(summary = "Get waitlist enrollments by student", description = "Retrieves all waitlist enrollments for a specific student (admin or the student themselves only)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved course waitlist enrollments",
+                    content = @Content(schema = @Schema(implementation = WaitlistEnrollmentResponseDto.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing token"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient permissions")
+    })
+    @GetMapping("/student/{studentId}")
+    public ResponseEntity<List<WaitlistEnrollmentResponseDto>> getWaitlistEnrollmentsByStudentId(
+            @Parameter(description = "ID of the student", required = true) 
+            @PathVariable Long studentId,
             @AuthenticationPrincipal UserDetails currentUser) {
-        if (!isAdmin(currentUser)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        
-        List<WaitlistEnrollment> allEnrollments = waitlistEnrollmentService.getAllWaitlistEnrollments();
-        List<WaitlistEnrollment> courseEnrollments = allEnrollments.stream()
-                .filter(e -> e.getWaitlist().getCourse().getId().equals(courseId))
-                .collect(Collectors.toList());
-        
-        return ResponseEntity.ok(courseEnrollments);
+        return ResponseEntity.ok(waitlistEnrollmentService.getWaitlistEnrollmentsByStudentId(studentId, currentUser));
     }
 
-    private void updateWaitlistPositions(Long waitlistId) {
+     /* private void updateWaitlistPositions(Long waitlistId) {
         List<WaitlistEnrollment> enrollments = waitlistEnrollmentService.getAllWaitlistEnrollments().stream()
                 .filter(e -> e.getWaitlist().getId().equals(waitlistId))
                 .sorted(Comparator.comparingInt(WaitlistEnrollment::getWaitlistPosition))
@@ -135,5 +107,5 @@ public class WaitlistEnrollmentController {
 
     private boolean isStudent(UserDetails currentUser, Long studentId) {
         return currentUser.getUsername().equals(studentId.toString());
-    }
+    } */
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/CourseResponseDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/CourseResponseDto.java
@@ -19,6 +19,7 @@ public class CourseResponseDto {
     private LocalTime startTime;
     private LocalTime endTime;
     private Integer numLabSection;
+    private WaitlistResponseDto waitlist;
 
     public CourseResponseDto() {
     }
@@ -42,6 +43,7 @@ public class CourseResponseDto {
         this.startTime = startTime;
         this.endTime = endTime;
         this.numLabSection = numLabSection;
+        this.waitlist = null; 
     }
 
     public Long getId() {
@@ -162,5 +164,13 @@ public class CourseResponseDto {
 
     public void setNumLabSection(Integer numLabSection) {
         this.numLabSection = numLabSection;
+    }
+
+    public WaitlistResponseDto getWaitlist() {
+        return waitlist;
+    }
+
+    public void setWaitlist(WaitlistResponseDto waitlist) {
+        this.waitlist = waitlist;
     }
 } 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/CourseResponseDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/CourseResponseDto.java
@@ -3,6 +3,9 @@ package com.hackademics.dto;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import com.hackademics.model.OfferingType;
+
+
 public class CourseResponseDto {
     private Long id;
     private AdminSummaryDto admin;
@@ -20,6 +23,7 @@ public class CourseResponseDto {
     private LocalTime endTime;
     private Integer numLabSection;
     private WaitlistResponseDto waitlist;
+    private OfferingType offeringType;
 
     public CourseResponseDto() {
     }
@@ -44,6 +48,8 @@ public class CourseResponseDto {
         this.endTime = endTime;
         this.numLabSection = numLabSection;
         this.waitlist = null; 
+        this.offeringType = OfferingType.COURSE;
+
     }
 
     public Long getId() {
@@ -172,5 +178,18 @@ public class CourseResponseDto {
 
     public void setWaitlist(WaitlistResponseDto waitlist) {
         this.waitlist = waitlist;
+        if (waitlist != null) {
+            this.offeringType = OfferingType.WAITLIST;
+        } else {
+            this.offeringType = OfferingType.COURSE;
+        }
+    }
+
+    public OfferingType getOfferingType() {
+        return offeringType;
+    }
+
+    public void setOfferingType(OfferingType offeringType) {
+        this.offeringType = offeringType;
     }
 } 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/GradeDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/GradeDto.java
@@ -1,0 +1,38 @@
+package com.hackademics.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class GradeDto {
+    @NotNull(message = "Student ID is required")
+    private Long studentId;
+    
+    @NotNull(message = "Course ID is required")
+    private Long courseId;
+    
+    @NotNull(message = "Grade is required")
+    @Min(value = 0, message = "Grade must be between 0 and 100")
+    @Max(value = 100, message = "Grade must be between 0 and 100")
+    private Double grade;
+
+    public GradeDto() {
+    }
+
+    public GradeDto(Long studentId, Long courseId, Double grade) {
+        this.studentId = studentId;
+        this.courseId = courseId;
+        this.grade = grade;
+    }
+
+    public Long getStudentId() {
+        return studentId;
+    }   
+    public Long getCourseId() {
+        return courseId;
+    }
+    public Double getGrade() {
+        return grade;
+    }
+    
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/GradeResponseDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/GradeResponseDto.java
@@ -1,0 +1,33 @@
+package com.hackademics.dto;
+
+public class GradeResponseDto {
+    private Long id; 
+    private Double grade;
+    private StudentSummaryDto student; 
+    private CourseResponseDto course;
+
+    public GradeResponseDto() {
+    }
+
+    public GradeResponseDto(Long id, Double grade, StudentSummaryDto student, CourseResponseDto course) {
+        this.id = id;
+        this.grade = grade;
+        this.student = student;
+        this.course = course;
+    }
+
+    public Long getId() {
+        return id;
+    }
+    public Double getGrade() {
+        return grade;
+    }
+    public StudentSummaryDto getStudent() {
+        return student;
+    }
+    public CourseResponseDto getCourse() {
+        return course;
+    }
+    
+    
+}

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/GradeUpdateDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/GradeUpdateDto.java
@@ -1,0 +1,23 @@
+package com.hackademics.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public class GradeUpdateDto {
+    @NotNull(message = "Grade is required")
+    @Min(value = 0, message = "Grade must be between 0 and 100")
+    @Max(value = 100, message = "Grade must be between 0 and 100")
+    private Double grade;
+
+    public GradeUpdateDto() {
+    }
+
+    public GradeUpdateDto(Double grade) {
+        this.grade = grade;
+    }
+
+    public Double getGrade() {
+        return grade;
+    }
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistDto.java
@@ -1,0 +1,37 @@
+package com.hackademics.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class WaitlistDto {
+    @NotNull(message = "Course ID is required")
+    private Long courseId;
+    
+    @NotNull(message = "Capacity is required")
+    @Min(value = 1, message = "Capacity must be at least 1")
+    private Integer capacity;
+
+    public WaitlistDto() {
+    }
+
+    public WaitlistDto(Long courseId, Integer capacity) {
+        this.courseId = courseId;
+        this.capacity = capacity;
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public void setCourseId(Long courseId) {
+        this.courseId = courseId;
+    }
+
+    public Integer getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(Integer capacity) {
+        this.capacity = capacity;
+    }
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistEnrollmentDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistEnrollmentDto.java
@@ -1,0 +1,35 @@
+package com.hackademics.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class WaitlistEnrollmentDto {
+    @NotNull(message = "Waitlist ID is required")
+    private Long waitlistId;
+
+    @NotNull(message = "Student ID is required")
+    private Long studentId;
+
+    public WaitlistEnrollmentDto(){}
+
+    public WaitlistEnrollmentDto(Long waitlistId, Long studentId){
+        this.waitlistId = waitlistId;
+        this.studentId = studentId;
+    }
+
+    public Long getWaitlistId(){
+        return waitlistId;
+        }
+
+    public void setWaitlistId(Long waitlistId){
+        this.waitlistId = waitlistId;
+    }
+
+    public Long getStudentId(){
+        return studentId;
+    }
+
+    public void setStudentId(Long studentId){
+        this.studentId = studentId;
+    }
+    
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistEnrollmentResponseDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistEnrollmentResponseDto.java
@@ -1,0 +1,61 @@
+package com.hackademics.dto;
+
+
+public class WaitlistEnrollmentResponseDto {
+    private Long id;
+    private Integer waitlistPosition;
+    private WaitlistResponseDto waitlistResponseDto;
+    private StudentSummaryDto studentSummaryDto;
+    private String term;
+
+    public WaitlistEnrollmentResponseDto(){}
+
+    public WaitlistEnrollmentResponseDto(Long id, Integer waitlistPosition, WaitlistResponseDto waitlistResponseDto, StudentSummaryDto studentSummaryDto, String term){
+        this.id = id;
+        this.waitlistPosition = waitlistPosition;
+        this.waitlistResponseDto = waitlistResponseDto;
+        this.studentSummaryDto = studentSummaryDto;
+        this.term = term;
+    }
+
+    public Long getId(){
+        return id;
+    }
+
+    public void setId(Long id){
+        this.id = id;
+    }
+
+    public Integer getWaitlistPosition(){
+        return waitlistPosition;
+    }
+
+    public void setWaitlistPosition(Integer waitlistPosition){
+        this.waitlistPosition = waitlistPosition;
+    }
+
+    public WaitlistResponseDto getWaitlistResponseDto(){
+        return waitlistResponseDto;
+    }
+
+    public void setWaitlistResponseDto(WaitlistResponseDto waitlistResponseDto){
+        this.waitlistResponseDto = waitlistResponseDto;
+    }
+
+    public StudentSummaryDto getStudentSummaryDto(){
+        return studentSummaryDto;
+    }
+
+    public void setStudentSummaryDto(StudentSummaryDto studentSummaryDto){
+        this.studentSummaryDto = studentSummaryDto;
+    }
+
+    public String getTerm(){
+        return term;
+    }
+
+    public void setTerm(String term){
+        this.term = term;
+    }
+
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistResponseDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistResponseDto.java
@@ -1,0 +1,40 @@
+package com.hackademics.dto;
+
+public class WaitlistResponseDto {
+    private Long waitlistId;
+    private Integer capacity;
+    private CourseResponseDto course;
+
+    public WaitlistResponseDto() {
+    }
+
+    public WaitlistResponseDto(Long waitlistId, Integer capacity, CourseResponseDto course) {
+        this.waitlistId = waitlistId;
+        this.capacity = capacity;
+        this.course = course;
+    }
+
+    public Long getWaitlistId() {
+        return waitlistId;
+    }
+
+    public void setWaitlistId(Long waitlistId) {
+        this.waitlistId = waitlistId;
+    }
+
+    public Integer getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(Integer capacity) {
+        this.capacity = capacity;
+    }
+
+    public CourseResponseDto getCourse() {
+        return course;
+    }
+
+    public void setCourse(CourseResponseDto course) {
+        this.course = course;
+    }
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistUpdateDto.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/dto/WaitlistUpdateDto.java
@@ -1,0 +1,25 @@
+package com.hackademics.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class WaitlistUpdateDto {
+    @NotNull(message = "Capacity is required")
+    @Min(value = 1, message = "Capacity must be at least 1")
+    private Integer capacity;
+
+    public WaitlistUpdateDto() {
+    }
+
+    public WaitlistUpdateDto(Integer capacity) {
+        this.capacity = capacity;
+    }
+
+    public Integer getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(Integer capacity) {
+        this.capacity = capacity;
+    }
+} 

--- a/Projecta-Backend/src/main/java/com/hackademics/model/Course.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/Course.java
@@ -77,6 +77,9 @@ public class Course {
     @Column(name = "Lab_sections") 
     private int numLabSections; 
 
+    @Column(name = "waitlist_available")
+    private boolean waitlistAvailable;
+
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private final List<Grade> grades = new ArrayList<>();
@@ -110,6 +113,7 @@ public class Course {
         this.startTime = startTime; 
         this.endTime = endTime;
         this.numLabSections = 0;
+        this.waitlistAvailable = false;
     }
 
     // Getters and Setters
@@ -261,5 +265,11 @@ public class Course {
         return labSections;
     }
 
+    public boolean isWaitlistAvailable() {
+        return waitlistAvailable;
+    }
 
+    public void setWaitlistAvailable(boolean waitlistAvailable) {
+        this.waitlistAvailable = waitlistAvailable;
+    }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/model/OfferingType.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/OfferingType.java
@@ -1,0 +1,5 @@
+package com.hackademics.model;
+
+public enum OfferingType {
+    COURSE, WAITLIST
+}

--- a/Projecta-Backend/src/main/java/com/hackademics/model/Waitlist.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/Waitlist.java
@@ -30,7 +30,7 @@ public class Waitlist {
     private Course course;
 
     @Column(name = "waitlist_limit", nullable = false)
-    private int waitlistLimit;
+    private Integer waitlistLimit;
 
     @OneToMany(mappedBy = "waitlist", cascade = CascadeType.ALL, orphanRemoval=true)
     @OnDelete(action = OnDeleteAction.CASCADE)
@@ -42,7 +42,7 @@ public class Waitlist {
 
     public Waitlist(){}
 
-    public Waitlist (Course course, int waitlistLimit){
+    public Waitlist (Course course, Integer waitlistLimit){
         this.course = course;
         this.waitlistLimit = waitlistLimit;
         this.term = course.getTerm(); 
@@ -66,11 +66,11 @@ public class Waitlist {
         this.course = course;
     }
 
-    public int getWaitlistLimit() {
+    public Integer getWaitlistLimit() {
         return waitlistLimit;
     }
 
-    public void setWaitlistLimit(int waitlistLimit) {
+    public void setWaitlistLimit(Integer waitlistLimit) {
         this.waitlistLimit = waitlistLimit;
     }
 

--- a/Projecta-Backend/src/main/java/com/hackademics/model/Waitlist.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/model/Waitlist.java
@@ -44,6 +44,7 @@ public class Waitlist {
 
     public Waitlist (Course course, Integer waitlistLimit){
         this.course = course;
+        this.course.setWaitlistAvailable(true);
         this.waitlistLimit = waitlistLimit;
         this.term = course.getTerm(); 
     }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/CourseService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/CourseService.java
@@ -7,8 +7,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import com.hackademics.dto.CourseDto;
 import com.hackademics.dto.CourseResponseDto;
 import com.hackademics.dto.CourseUpdateDto;
+import com.hackademics.model.Course;
 
 public interface CourseService {
+    CourseResponseDto convertToResponseDto(Course course);
     CourseResponseDto saveCourse(CourseDto courseDto, UserDetails currentUser);
     List<CourseResponseDto> getAllActiveCourses();
     List<CourseResponseDto> getAllUpcomingCourses();

--- a/Projecta-Backend/src/main/java/com/hackademics/service/GradeService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/GradeService.java
@@ -2,14 +2,19 @@ package com.hackademics.service;
 
 import java.util.List;
 
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.hackademics.dto.GradeDto;
+import com.hackademics.dto.GradeUpdateDto;
 import com.hackademics.model.Grade;
 
 public interface GradeService {
 
-    Grade saveGrade(Grade grade); 
-    List<Grade> getAllGrades();
-    Grade getGradeById(Long id); 
-    Grade updateGrade(Grade grade); 
-    void deleteGrade(Long id); 
+    Grade saveGrade(GradeDto gradeDto, UserDetails currentUser); 
+    List<Grade> getAllGrades(UserDetails currentUser);
+    Grade getGradeById(Long id, UserDetails currentUser); 
+    Grade updateGrade(Long id, GradeUpdateDto gradeUpdateDto, UserDetails currentUser); 
+    void deleteGrade(Long id, UserDetails currentUser); 
+    List<Grade> getGradesByStudentId(Long studentId, UserDetails currentUser);
     
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/GradeService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/GradeService.java
@@ -6,15 +6,15 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import com.hackademics.dto.GradeDto;
 import com.hackademics.dto.GradeUpdateDto;
-import com.hackademics.model.Grade;
+import com.hackademics.dto.GradeResponseDto;
 
 public interface GradeService {
 
-    Grade saveGrade(GradeDto gradeDto, UserDetails currentUser); 
-    List<Grade> getAllGrades(UserDetails currentUser);
-    Grade getGradeById(Long id, UserDetails currentUser); 
-    Grade updateGrade(Long id, GradeUpdateDto gradeUpdateDto, UserDetails currentUser); 
+    GradeResponseDto saveGrade(GradeDto gradeDto, UserDetails currentUser); 
+    List<GradeResponseDto> getAllGrades(UserDetails currentUser);
+    GradeResponseDto getGradeById(Long id, UserDetails currentUser); 
+    GradeResponseDto updateGrade(Long id, GradeUpdateDto gradeUpdateDto, UserDetails currentUser); 
     void deleteGrade(Long id, UserDetails currentUser); 
-    List<Grade> getGradesByStudentId(Long studentId, UserDetails currentUser);
+    List<GradeResponseDto> getGradesByStudentId(Long studentId, UserDetails currentUser);
     
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/WaitlistEnrollmentService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/WaitlistEnrollmentService.java
@@ -1,13 +1,15 @@
 package com.hackademics.service;
 
-import com.hackademics.model.WaitlistEnrollment;
 import java.util.List;
 
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.hackademics.dto.WaitlistEnrollmentDto;
+import com.hackademics.dto.WaitlistEnrollmentResponseDto;
+
 public interface WaitlistEnrollmentService {
-    WaitlistEnrollment saveWaitlistEnrollment(WaitlistEnrollment waitlistEnrollment);
-    List<WaitlistEnrollment> getAllWaitlistEnrollments();
-    WaitlistEnrollment getWaitlistEnrollmentById(Long id);
-    WaitlistEnrollment updateWaitlistEnrollment(WaitlistEnrollment waitlistEnrollment);
-    void deleteWaitlistEnrollment(Long id);
+    WaitlistEnrollmentResponseDto saveWaitlistEnrollment(WaitlistEnrollmentDto waitlistEnrollmentDto, UserDetails currentUser);
+    void deleteWaitlistEnrollment(Long id, UserDetails currentUser);
+    List<WaitlistEnrollmentResponseDto> getWaitlistEnrollmentsByStudentId(Long studentId, UserDetails currentUser);
 }
 

--- a/Projecta-Backend/src/main/java/com/hackademics/service/WaitlistService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/WaitlistService.java
@@ -5,10 +5,12 @@ import java.util.List;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import com.hackademics.dto.WaitlistDto;
-import com.hackademics.dto.WaitlistUpdateDto;
 import com.hackademics.dto.WaitlistResponseDto;
+import com.hackademics.dto.WaitlistUpdateDto;
+import com.hackademics.model.Waitlist;
 
 public interface WaitlistService {
+    WaitlistResponseDto convertToResponseDto(Waitlist waitlist);
     WaitlistResponseDto saveWaitlist(WaitlistDto waitlistDto, UserDetails currentUser);
     List<WaitlistResponseDto> getAllWaitlists(UserDetails currentUser);
     WaitlistResponseDto getWaitlistById(Long id, UserDetails currentUser);

--- a/Projecta-Backend/src/main/java/com/hackademics/service/WaitlistService.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/WaitlistService.java
@@ -2,12 +2,16 @@ package com.hackademics.service;
 
 import java.util.List;
 
-import com.hackademics.model.Waitlist;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.hackademics.dto.WaitlistDto;
+import com.hackademics.dto.WaitlistUpdateDto;
+import com.hackademics.dto.WaitlistResponseDto;
 
 public interface WaitlistService {
-    Waitlist saveWaitlist(Waitlist waitlist);
-    List<Waitlist> getAllWaitlists();
-    Waitlist getWaitlistById(Long id);
-    Waitlist updateWaitlist(Waitlist waitlist);
-    void deleteWaitlist(Long id);
+    WaitlistResponseDto saveWaitlist(WaitlistDto waitlistDto, UserDetails currentUser);
+    List<WaitlistResponseDto> getAllWaitlists(UserDetails currentUser);
+    WaitlistResponseDto getWaitlistById(Long id, UserDetails currentUser);
+    WaitlistResponseDto updateWaitlist(Long id, WaitlistUpdateDto waitlistUpdateDto, UserDetails currentUser);
+    void deleteWaitlist(Long id, UserDetails currentUser);
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/CourseServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/CourseServiceImpl.java
@@ -37,7 +37,8 @@ public class CourseServiceImpl implements CourseService {
     @Autowired
     private SubjectRepository subjectRepository;
 
-    private CourseResponseDto convertToResponseDto(Course course) {
+    @Override
+    public CourseResponseDto convertToResponseDto(Course course) {
         AdminSummaryDto adminDto = new AdminSummaryDto(
             course.getAdmin().getId(),
             course.getAdmin().getFirstName(),

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/CourseServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/CourseServiceImpl.java
@@ -15,6 +15,7 @@ import com.hackademics.dto.CourseDto;
 import com.hackademics.dto.CourseResponseDto;
 import com.hackademics.dto.CourseUpdateDto;
 import com.hackademics.dto.SubjectResponseDto;
+import com.hackademics.dto.WaitlistResponseDto;
 import com.hackademics.model.Course;
 import com.hackademics.model.Role;
 import com.hackademics.model.Subject;
@@ -25,7 +26,6 @@ import com.hackademics.repository.SubjectRepository;
 import com.hackademics.repository.UserRepository;
 import com.hackademics.repository.WaitlistRepository;
 import com.hackademics.service.CourseService;
-import com.hackademics.service.WaitlistService;
 import com.hackademics.util.TermDeterminator;
 
 @Service
@@ -43,8 +43,13 @@ public class CourseServiceImpl implements CourseService {
     @Autowired
     private WaitlistRepository waitlistRepository;
 
-    @Autowired
-    private WaitlistService waitlistService;
+    private WaitlistResponseDto convertWaitlistToResponseDto(Waitlist waitlist, CourseResponseDto courseResponseDto) {
+        return new WaitlistResponseDto(
+            waitlist.getId(),
+            waitlist.getWaitlistLimit(),
+            courseResponseDto
+        );
+    }
 
     @Override
     public CourseResponseDto convertToResponseDto(Course course) {
@@ -236,11 +241,9 @@ public class CourseServiceImpl implements CourseService {
             Waitlist waitlist = waitlistRepository.findByCourseId(course.getId());
             if (waitlist != null) {
                 if (waitlist.getWaitlistEnrollments().size() < waitlist.getWaitlistLimit()) {
-                    courseResponse.setWaitlist(waitlistService.convertToResponseDto(waitlist));
+                    courseResponse.setWaitlist(convertWaitlistToResponseDto(waitlist, courseResponse));
                 }
             }
         }
-
     }
-
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/GradeServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/GradeServiceImpl.java
@@ -1,12 +1,21 @@
 package com.hackademics.service.impl;
 
 import java.util.List;
+import java.util.stream.Collectors;
  
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import com.hackademics.dto.GradeDto;
+import com.hackademics.dto.GradeUpdateDto;
+import com.hackademics.model.Course;
 import com.hackademics.model.Grade;
+import com.hackademics.model.Role;
+import com.hackademics.model.User;
+import com.hackademics.repository.CourseRepository;
 import com.hackademics.repository.GradeRepository;
+import com.hackademics.repository.UserRepository;
 import com.hackademics.service.GradeService;
 
 @Service
@@ -15,29 +24,95 @@ public class GradeServiceImpl implements GradeService {
     @Autowired
     private GradeRepository gradeRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
     @Override
-    public Grade saveGrade(Grade grade) {
+    public Grade saveGrade(GradeDto gradeDto, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can create grades.");
+        }
+
+        User student = userRepository.findById(gradeDto.getStudentId())
+                .orElseThrow(() -> new RuntimeException("Student not found with ID: " + gradeDto.getStudentId()));
+        
+        Course course = courseRepository.findById(gradeDto.getCourseId())
+                .orElseThrow(() -> new RuntimeException("Course not found with ID: " + gradeDto.getCourseId()));
+        
+        Grade grade = new Grade(student, course, gradeDto.getGrade());
         return gradeRepository.save(grade);
     }
 
     @Override
-    public List<Grade> getAllGrades() {
+    public List<Grade> getAllGrades(UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can view all grades.");
+        }
+        
         return gradeRepository.findAll();
     }
 
     @Override
-    public Grade getGradeById(Long id) {
+    public Grade getGradeById(Long id, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can view grade details.");
+        }
+        
         return gradeRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Grade not found with ID: " + id));
     }
 
     @Override
-    public Grade updateGrade(Grade grade) {
+    public Grade updateGrade(Long id, GradeUpdateDto gradeUpdateDto, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can update grades.");
+        }
+        
+        Grade grade = gradeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Grade not found with ID: " + id));
+        
+        grade.setGrade(gradeUpdateDto.getGrade());
         return gradeRepository.save(grade);
     }
 
     @Override
-    public void deleteGrade(Long id) {
+    public void deleteGrade(Long id, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can delete grades.");
+        }
+        
         gradeRepository.deleteById(id);
+    }
+
+    @Override
+    public List<Grade> getGradesByStudentId(Long studentId, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN && !user.getId().equals(studentId)) {
+            throw new RuntimeException("Access denied. You can only view your own grades.");
+        }
+        
+        return gradeRepository.findAll().stream()
+                .filter(grade -> grade.getStudent().getId().equals(studentId))
+                .collect(Collectors.toList());
     }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistEnrollmentServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistEnrollmentServiceImpl.java
@@ -90,11 +90,11 @@ public class WaitlistEnrollmentServiceImpl implements WaitlistEnrollmentService 
                 .orElseThrow(() -> new RuntimeException("Waitlist not found with ID: " + waitlistEnrollmentDto.getWaitlistId()));
         
         // Get the student
-        User student = userRepository.findById(waitlistEnrollmentDto.getStudentId())
+        User student = userRepository.findByStudentId(waitlistEnrollmentDto.getStudentId())
                 .orElseThrow(() -> new RuntimeException("Student not found with ID: " + waitlistEnrollmentDto.getStudentId()));
         
         // Check if user is admin or the student themselves
-        if (user.getRole() != Role.ADMIN && !user.getId().equals(student.getId())) {
+        if (user.getRole() != Role.ADMIN && !user.getStudentId().equals(student.getStudentId())) {
             throw new RuntimeException("Access denied. Only admins or the student themselves can create waitlist enrollments.");
         }
         
@@ -120,13 +120,13 @@ public class WaitlistEnrollmentServiceImpl implements WaitlistEnrollmentService 
                 .orElseThrow(() -> new RuntimeException("WaitlistEnrollment not found with ID: " + id));
         
         // Allow deletion if user is admin or if the enrollment belongs to the student
-        if (user.getRole() != Role.ADMIN && !enrollment.getStudent().getId().equals(user.getId())) {
+        if (user.getRole() != Role.ADMIN && !user.getStudentId().equals(enrollment.getStudent().getStudentId())) {
             throw new RuntimeException("Access denied. You can only delete your own waitlist enrollments.");
         }
 
-        updateWaitlistPositions(enrollment.getWaitlist().getId());
-        
+        // Delete first, then update positions
         waitlistEnrollmentRepository.deleteById(id);
+        updateWaitlistPositions(enrollment.getWaitlist().getId());
     }
 
     @Override

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistEnrollmentServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistEnrollmentServiceImpl.java
@@ -1,12 +1,27 @@
 package com.hackademics.service.impl;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import com.hackademics.dto.AdminSummaryDto;
+import com.hackademics.dto.CourseResponseDto;
+import com.hackademics.dto.StudentSummaryDto;
+import com.hackademics.dto.SubjectResponseDto;
+import com.hackademics.dto.WaitlistEnrollmentDto;
+import com.hackademics.dto.WaitlistEnrollmentResponseDto;
+import com.hackademics.dto.WaitlistResponseDto;
+import com.hackademics.model.Role;
+import com.hackademics.model.User;
+import com.hackademics.model.Waitlist;
 import com.hackademics.model.WaitlistEnrollment;
+import com.hackademics.repository.UserRepository;
 import com.hackademics.repository.WaitlistEnrollmentRepository;
+import com.hackademics.repository.WaitlistRepository;
 import com.hackademics.service.WaitlistEnrollmentService;
 
 @Service
@@ -15,29 +30,129 @@ public class WaitlistEnrollmentServiceImpl implements WaitlistEnrollmentService 
     @Autowired
     private WaitlistEnrollmentRepository waitlistEnrollmentRepository;
 
-    @Override
-    public WaitlistEnrollment saveWaitlistEnrollment(WaitlistEnrollment waitlistEnrollment) {
-        return waitlistEnrollmentRepository.save(waitlistEnrollment);
+    @Autowired
+    private WaitlistRepository waitlistRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private WaitlistEnrollmentResponseDto convertToResponseDto(WaitlistEnrollment enrollment) {
+        return new WaitlistEnrollmentResponseDto(
+            enrollment.getId(),
+            enrollment.getWaitlistPosition(),
+            new WaitlistResponseDto(
+                enrollment.getWaitlist().getId(),
+                enrollment.getWaitlist().getWaitlistLimit(),
+                new CourseResponseDto(
+                    enrollment.getWaitlist().getCourse().getId(),
+                    new AdminSummaryDto(
+                        enrollment.getWaitlist().getCourse().getAdmin().getId(),
+                        enrollment.getWaitlist().getCourse().getAdmin().getFirstName(),
+                        enrollment.getWaitlist().getCourse().getAdmin().getLastName(),
+                        enrollment.getWaitlist().getCourse().getAdmin().getAdminId()
+                    ),
+                    new SubjectResponseDto(
+                        enrollment.getWaitlist().getCourse().getSubject().getId(),
+                        enrollment.getWaitlist().getCourse().getSubject().getSubjectName(),
+                        enrollment.getWaitlist().getCourse().getSubject().getSubjectTag()
+                    ),
+                    enrollment.getWaitlist().getCourse().getCourseName(),
+                    enrollment.getWaitlist().getCourse().getStartDate().toLocalDate(),
+                    enrollment.getWaitlist().getCourse().getEndDate().toLocalDate(),
+                    enrollment.getWaitlist().getCourse().getEnrollLimit(),
+                    enrollment.getWaitlist().getCourse().getCurrentEnroll(),
+                    enrollment.getWaitlist().getCourse().getCourseNumber(),
+                    enrollment.getWaitlist().getCourse().getCourseTag(),
+                    enrollment.getWaitlist().getCourse().getTerm(),
+                    enrollment.getWaitlist().getCourse().getDays(),
+                    enrollment.getWaitlist().getCourse().getStartTime(),
+                    enrollment.getWaitlist().getCourse().getEndTime(),
+                    enrollment.getWaitlist().getCourse().getNumLabSections()
+                )
+            ),
+            new StudentSummaryDto(
+                enrollment.getStudent().getId(),
+                enrollment.getStudent().getFirstName(),
+                enrollment.getStudent().getLastName(),
+                enrollment.getStudent().getStudentId()
+            ),
+            enrollment.getTerm()
+        );
     }
 
     @Override
-    public List<WaitlistEnrollment> getAllWaitlistEnrollments() {
-        return waitlistEnrollmentRepository.findAll();
+    public WaitlistEnrollmentResponseDto saveWaitlistEnrollment(WaitlistEnrollmentDto waitlistEnrollmentDto, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        // Get the waitlist
+        Waitlist waitlist = waitlistRepository.findById(waitlistEnrollmentDto.getWaitlistId())
+                .orElseThrow(() -> new RuntimeException("Waitlist not found with ID: " + waitlistEnrollmentDto.getWaitlistId()));
+        
+        // Get the student
+        User student = userRepository.findById(waitlistEnrollmentDto.getStudentId())
+                .orElseThrow(() -> new RuntimeException("Student not found with ID: " + waitlistEnrollmentDto.getStudentId()));
+        
+        // Check if user is admin or the student themselves
+        if (user.getRole() != Role.ADMIN && !user.getId().equals(student.getId())) {
+            throw new RuntimeException("Access denied. Only admins or the student themselves can create waitlist enrollments.");
+        }
+        
+        // Count current enrollments
+        List<WaitlistEnrollment> currentEnrollments = waitlistEnrollmentRepository.findByWaitlistId(waitlist.getId());
+        
+        // Check capacity
+        if (currentEnrollments.size() >= waitlist.getWaitlistLimit()) {
+            throw new RuntimeException("Waitlist is at capacity. Cannot add more enrollments.");
+        }
+        
+        // Create and save the enrollment
+        WaitlistEnrollment enrollment = new WaitlistEnrollment(currentEnrollments.size() + 1, waitlist, student);
+        return convertToResponseDto(waitlistEnrollmentRepository.save(enrollment));
     }
 
     @Override
-    public WaitlistEnrollment getWaitlistEnrollmentById(Long id) {
-        return waitlistEnrollmentRepository.findById(id)
+    public void deleteWaitlistEnrollment(Long id, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        WaitlistEnrollment enrollment = waitlistEnrollmentRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("WaitlistEnrollment not found with ID: " + id));
-    }
+        
+        // Allow deletion if user is admin or if the enrollment belongs to the student
+        if (user.getRole() != Role.ADMIN && !enrollment.getStudent().getId().equals(user.getId())) {
+            throw new RuntimeException("Access denied. You can only delete your own waitlist enrollments.");
+        }
 
-    @Override
-    public WaitlistEnrollment updateWaitlistEnrollment(WaitlistEnrollment waitlistEnrollment) {
-        return waitlistEnrollmentRepository.save(waitlistEnrollment);
-    }
-
-    @Override
-    public void deleteWaitlistEnrollment(Long id) {
+        updateWaitlistPositions(enrollment.getWaitlist().getId());
+        
         waitlistEnrollmentRepository.deleteById(id);
     }
+
+    @Override
+    public List<WaitlistEnrollmentResponseDto> getWaitlistEnrollmentsByStudentId(Long studentId, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN && !user.getStudentId().equals(studentId)) {
+            throw new RuntimeException("Access denied. Only admins or the student themselves can view waitlist enrollments.");
+        }
+        
+        return waitlistEnrollmentRepository.findByStudentId(studentId).stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    private void updateWaitlistPositions(Long waitlistId) {
+        List<WaitlistEnrollment> enrollments = waitlistEnrollmentRepository.findByWaitlistId(waitlistId).stream()
+                .sorted(Comparator.comparingInt(WaitlistEnrollment::getWaitlistPosition))
+                .collect(Collectors.toList());
+        
+        for (int i = 0; i < enrollments.size(); i++) {
+            WaitlistEnrollment enrollment = enrollments.get(i);
+            enrollment.setWaitlistPosition(i + 1);
+            waitlistEnrollmentRepository.save(enrollment);
+        }
+    }
+
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistServiceImpl.java
@@ -8,8 +8,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import com.hackademics.dto.WaitlistDto;
-import com.hackademics.dto.WaitlistUpdateDto;
 import com.hackademics.dto.WaitlistResponseDto;
+import com.hackademics.dto.WaitlistUpdateDto;
 import com.hackademics.model.Course;
 import com.hackademics.model.Role;
 import com.hackademics.model.User;
@@ -17,8 +17,8 @@ import com.hackademics.model.Waitlist;
 import com.hackademics.repository.CourseRepository;
 import com.hackademics.repository.UserRepository;
 import com.hackademics.repository.WaitlistRepository;
-import com.hackademics.service.WaitlistService;
 import com.hackademics.service.CourseService;
+import com.hackademics.service.WaitlistService;
 
 @Service
 public class WaitlistServiceImpl implements WaitlistService {
@@ -35,7 +35,8 @@ public class WaitlistServiceImpl implements WaitlistService {
     @Autowired
     private CourseService courseService;
 
-    private WaitlistResponseDto convertToResponseDto(Waitlist waitlist) {
+    @Override
+    public WaitlistResponseDto convertToResponseDto(Waitlist waitlist) {
         return new WaitlistResponseDto(
             waitlist.getId(),
             waitlist.getWaitlistLimit(),
@@ -116,6 +117,12 @@ public class WaitlistServiceImpl implements WaitlistService {
             throw new RuntimeException("Access denied. Only admins can delete waitlists.");
         }
         
+        Waitlist waitlist = waitlistRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Waitlist not found with ID: " + id));
+        
+        waitlist.getCourse().setWaitlistAvailable(false);
+        courseRepository.save(waitlist.getCourse());
         waitlistRepository.deleteById(id);
+
     }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistServiceImpl.java
@@ -1,13 +1,24 @@
 package com.hackademics.service.impl;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import com.hackademics.dto.WaitlistDto;
+import com.hackademics.dto.WaitlistUpdateDto;
+import com.hackademics.dto.WaitlistResponseDto;
+import com.hackademics.model.Course;
+import com.hackademics.model.Role;
+import com.hackademics.model.User;
 import com.hackademics.model.Waitlist;
+import com.hackademics.repository.CourseRepository;
+import com.hackademics.repository.UserRepository;
 import com.hackademics.repository.WaitlistRepository;
 import com.hackademics.service.WaitlistService;
+import com.hackademics.service.CourseService;
 
 @Service
 public class WaitlistServiceImpl implements WaitlistService {
@@ -15,29 +26,96 @@ public class WaitlistServiceImpl implements WaitlistService {
     @Autowired
     private WaitlistRepository waitlistRepository;
 
-    @Override
-    public Waitlist saveWaitlist(Waitlist waitlist) {
-        return waitlistRepository.save(waitlist);
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private CourseService courseService;
+
+    private WaitlistResponseDto convertToResponseDto(Waitlist waitlist) {
+        return new WaitlistResponseDto(
+            waitlist.getId(),
+            waitlist.getWaitlistLimit(),
+            courseService.convertToResponseDto(waitlist.getCourse())
+        );
     }
 
     @Override
-    public List<Waitlist> getAllWaitlists() {
-        return waitlistRepository.findAll();
+    public WaitlistResponseDto saveWaitlist(WaitlistDto waitlistDto, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can create waitlists.");
+        }
+
+        Course course = courseRepository.findById(waitlistDto.getCourseId())
+                .orElseThrow(() -> new RuntimeException("Course not found with ID: " + waitlistDto.getCourseId()));
+
+
+        Waitlist waitlist = new Waitlist(course, waitlistDto.getCapacity());
+
+        return convertToResponseDto(waitlistRepository.save(waitlist));
     }
 
     @Override
-    public Waitlist getWaitlistById(Long id) {
-        return waitlistRepository.findById(id)
+    public List<WaitlistResponseDto> getAllWaitlists(UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can view all waitlists.");
+        }
+        
+        return waitlistRepository.findAll().stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public WaitlistResponseDto getWaitlistById(Long id, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        Waitlist waitlist = waitlistRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Waitlist not found with ID: " + id));
+        
+        // Allow access if user is admin or if the waitlist belongs to the user's course
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can view waitlists.");
+        }
+        
+        return convertToResponseDto(waitlist);
     }
 
     @Override
-    public Waitlist updateWaitlist(Waitlist waitlist) {
-        return waitlistRepository.save(waitlist);
+    public WaitlistResponseDto updateWaitlist(Long id, WaitlistUpdateDto waitlistUpdateDto, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can update waitlists.");
+        }
+        
+        Waitlist waitlist = waitlistRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Waitlist not found with ID: " + id));
+        
+        waitlist.setWaitlistLimit(waitlistUpdateDto.getCapacity());
+        return convertToResponseDto(waitlistRepository.save(waitlist));
     }
 
     @Override
-    public void deleteWaitlist(Long id) {
+    public void deleteWaitlist(Long id, UserDetails currentUser) {
+        User user = userRepository.findByEmail(currentUser.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("Access denied. Only admins can delete waitlists.");
+        }
+        
         waitlistRepository.deleteById(id);
     }
 }

--- a/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistServiceImpl.java
+++ b/Projecta-Backend/src/main/java/com/hackademics/service/impl/WaitlistServiceImpl.java
@@ -7,6 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import com.hackademics.dto.AdminSummaryDto;
+import com.hackademics.dto.CourseResponseDto;
+import com.hackademics.dto.SubjectResponseDto;
 import com.hackademics.dto.WaitlistDto;
 import com.hackademics.dto.WaitlistResponseDto;
 import com.hackademics.dto.WaitlistUpdateDto;
@@ -17,7 +20,6 @@ import com.hackademics.model.Waitlist;
 import com.hackademics.repository.CourseRepository;
 import com.hackademics.repository.UserRepository;
 import com.hackademics.repository.WaitlistRepository;
-import com.hackademics.service.CourseService;
 import com.hackademics.service.WaitlistService;
 
 @Service
@@ -32,15 +34,45 @@ public class WaitlistServiceImpl implements WaitlistService {
     @Autowired
     private CourseRepository courseRepository;
 
-    @Autowired
-    private CourseService courseService;
+    private CourseResponseDto convertCourseToResponseDto(Course course) {
+        AdminSummaryDto adminDto = new AdminSummaryDto(
+            course.getAdmin().getId(),
+            course.getAdmin().getFirstName(),
+            course.getAdmin().getLastName(),
+            course.getAdmin().getAdminId()
+        );
+
+        SubjectResponseDto subjectDto = new SubjectResponseDto(
+            course.getSubject().getId(),
+            course.getSubject().getSubjectName(),
+            course.getSubject().getSubjectTag()
+        );
+
+        return new CourseResponseDto(
+            course.getId(),
+            adminDto,
+            subjectDto,
+            course.getCourseName(),
+            course.getStartDate().toLocalDate(),
+            course.getEndDate().toLocalDate(),
+            course.getEnrollLimit(),
+            course.getCurrentEnroll(),
+            course.getCourseNumber(),
+            course.getCourseTag(),
+            course.getTerm(),
+            course.getDays(),
+            course.getStartTime(),
+            course.getEndTime(),
+            course.getNumLabSections()
+        );
+    }
 
     @Override
     public WaitlistResponseDto convertToResponseDto(Waitlist waitlist) {
         return new WaitlistResponseDto(
             waitlist.getId(),
             waitlist.getWaitlistLimit(),
-            courseService.convertToResponseDto(waitlist.getCourse())
+            convertCourseToResponseDto(waitlist.getCourse())
         );
     }
 
@@ -55,7 +87,6 @@ public class WaitlistServiceImpl implements WaitlistService {
 
         Course course = courseRepository.findById(waitlistDto.getCourseId())
                 .orElseThrow(() -> new RuntimeException("Course not found with ID: " + waitlistDto.getCourseId()));
-
 
         Waitlist waitlist = new Waitlist(course, waitlistDto.getCapacity());
 
@@ -123,6 +154,5 @@ public class WaitlistServiceImpl implements WaitlistService {
         waitlist.getCourse().setWaitlistAvailable(false);
         courseRepository.save(waitlist.getCourse());
         waitlistRepository.deleteById(id);
-
     }
 }

--- a/Projecta-Backend/src/test/java/com/hackademics/controllerTest/GradeControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/controllerTest/GradeControllerTest.java
@@ -1,0 +1,250 @@
+package com.hackademics.controllerTest;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackademics.dto.GradeDto;
+import com.hackademics.dto.GradeUpdateDto;
+import com.hackademics.model.Course;
+import com.hackademics.model.Grade;
+import com.hackademics.model.Role;
+import com.hackademics.model.Subject;
+import com.hackademics.model.User;
+import com.hackademics.repository.CourseRepository;
+import com.hackademics.repository.GradeRepository;
+import com.hackademics.repository.SubjectRepository;
+import com.hackademics.repository.UserRepository;
+import com.hackademics.service.JwtService;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class GradeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GradeRepository gradeRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private User admin;
+    private User student1;
+    private User student2;
+    private Subject subject;
+    private Course course;
+    private Grade grade;
+
+    // Helper method
+    private String generateToken(User user) {
+        return jwtService.generateToken(user);
+    }
+
+    @BeforeEach
+    void setUp() {
+        gradeRepository.deleteAll();
+        courseRepository.deleteAll();
+        subjectRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Create test users
+        admin = new User("Admin", "User", "admin@example.com", passwordEncoder.encode("adminPass"), Role.ADMIN, 100L);
+        admin = userRepository.save(admin);
+
+        student1 = new User("Student1", "User", "student1@example.com", passwordEncoder.encode("studentPass"), Role.STUDENT, 123L);
+        student1 = userRepository.save(student1);
+
+        student2 = new User("Student2", "User", "student2@example.com", passwordEncoder.encode("studentPass"), Role.STUDENT, 456L);
+        student2 = userRepository.save(student2);
+
+        // Create test subject
+        subject = new Subject("Computer Science", "COSC");
+        subject = subjectRepository.save(subject);
+
+        // Create test course
+        course = new Course(
+            admin,
+            subject,
+            "Introduction to Programming",
+            LocalDateTime.now().plusDays(1),
+            LocalDateTime.now().plusMonths(4),
+            50,
+            "101",
+            1,
+            LocalTime.of(9, 0),
+            LocalTime.of(10, 30)
+        );
+        course = courseRepository.save(course);
+
+        // Create test grade
+        grade = new Grade(student1, course, 85.0);
+        grade = gradeRepository.save(grade);
+    }
+
+    // Essential endpoints tests
+    @Test
+    void shouldAllowAdminToCreateGrade() throws Exception {
+        GradeDto gradeDto = new GradeDto(student1.getStudentId(), course.getId(), 90.0);
+
+        mockMvc.perform(post("/api/grades")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(gradeDto))
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.student.studentId").value(student1.getStudentId()))
+                .andExpect(jsonPath("$.course.id").value(course.getId()))
+                .andExpect(jsonPath("$.grade").value(90.0));
+    }
+
+    @Test
+    void shouldNotAllowStudentToCreateGrade() throws Exception {
+        GradeDto gradeDto = new GradeDto(student1.getStudentId(), course.getId(), 90.0);
+
+        mockMvc.perform(post("/api/grades")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(gradeDto))
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowAdminToUpdateGrade() throws Exception {
+        GradeUpdateDto gradeUpdateDto = new GradeUpdateDto(95.0);
+
+        mockMvc.perform(put("/api/grades/" + grade.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(gradeUpdateDto))
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.grade").value(95.0));
+    }
+
+    @Test
+    void shouldNotAllowStudentToUpdateGrade() throws Exception {
+        GradeUpdateDto gradeUpdateDto = new GradeUpdateDto(95.0);
+
+        mockMvc.perform(put("/api/grades/" + grade.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(gradeUpdateDto))
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowStudentToViewTheirOwnGrade() throws Exception {
+        mockMvc.perform(get("/api/grades/" + grade.getId())
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.student.studentId").value(student1.getStudentId()))
+                .andExpect(jsonPath("$.course.id").value(course.getId()))
+                .andExpect(jsonPath("$.grade").value(85.0));
+    }
+
+    @Test
+    void shouldNotAllowStudentToViewOtherStudentGrade() throws Exception {
+        mockMvc.perform(get("/api/grades/" + grade.getId())
+                .header("Authorization", "Bearer " + generateToken(student2)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowAdminToViewAnyGrade() throws Exception {
+        mockMvc.perform(get("/api/grades/" + grade.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.student.studentId").value(student1.getStudentId()))
+                .andExpect(jsonPath("$.course.id").value(course.getId()))
+                .andExpect(jsonPath("$.grade").value(85.0));
+    }
+
+    @Test
+    void shouldAllowAdminToDeleteGrade() throws Exception {
+        mockMvc.perform(delete("/api/grades/" + grade.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldNotAllowStudentToDeleteGrade() throws Exception {
+        mockMvc.perform(delete("/api/grades/" + grade.getId())
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowStudentToViewTheirOwnGrades() throws Exception {
+        mockMvc.perform(get("/api/grades/student/" + student1.getStudentId())
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].student.studentId").value(student1.getStudentId()));
+    }
+
+    @Test
+    void shouldNotAllowStudentToViewOtherStudentGrades() throws Exception {
+        mockMvc.perform(get("/api/grades/student/" + student2.getStudentId())
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowAdminToViewAnyStudentGrades() throws Exception {
+        mockMvc.perform(get("/api/grades/student/" + student1.getStudentId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].student.studentId").value(student1.getStudentId()));
+    }
+
+    @Test
+    void shouldAllowAdminToGetAllGrades() throws Exception {
+        mockMvc.perform(get("/api/grades")
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    @Test
+    void shouldNotAllowStudentToGetAllGrades() throws Exception {
+        mockMvc.perform(get("/api/grades")
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/Projecta-Backend/src/test/java/com/hackademics/controllerTest/GradeControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/controllerTest/GradeControllerTest.java
@@ -141,7 +141,7 @@ class GradeControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(gradeDto))
                 .header("Authorization", "Bearer " + generateToken(student1)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -164,7 +164,7 @@ class GradeControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(gradeUpdateDto))
                 .header("Authorization", "Bearer " + generateToken(student1)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -181,7 +181,7 @@ class GradeControllerTest {
     void shouldNotAllowStudentToViewOtherStudentGrade() throws Exception {
         mockMvc.perform(get("/api/grades/" + grade.getId())
                 .header("Authorization", "Bearer " + generateToken(student2)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -205,7 +205,7 @@ class GradeControllerTest {
     void shouldNotAllowStudentToDeleteGrade() throws Exception {
         mockMvc.perform(delete("/api/grades/" + grade.getId())
                 .header("Authorization", "Bearer " + generateToken(student1)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -221,7 +221,7 @@ class GradeControllerTest {
     void shouldNotAllowStudentToViewOtherStudentGrades() throws Exception {
         mockMvc.perform(get("/api/grades/student/" + student2.getStudentId())
                 .header("Authorization", "Bearer " + generateToken(student1)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -245,6 +245,6 @@ class GradeControllerTest {
     void shouldNotAllowStudentToGetAllGrades() throws Exception {
         mockMvc.perform(get("/api/grades")
                 .header("Authorization", "Bearer " + generateToken(student1)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/Projecta-Backend/src/test/java/com/hackademics/controllerTest/WaitlistControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/controllerTest/WaitlistControllerTest.java
@@ -1,0 +1,223 @@
+package com.hackademics.controllerTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackademics.dto.WaitlistDto;
+import com.hackademics.dto.WaitlistUpdateDto;
+import com.hackademics.model.Course;
+import com.hackademics.model.Role;
+import com.hackademics.model.Subject;
+import com.hackademics.model.User;
+import com.hackademics.model.Waitlist;
+import com.hackademics.repository.CourseRepository;
+import com.hackademics.repository.SubjectRepository;
+import com.hackademics.repository.UserRepository;
+import com.hackademics.repository.WaitlistRepository;
+import com.hackademics.service.JwtService;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class WaitlistControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WaitlistRepository waitlistRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private User admin;
+    private User student;
+    private Subject subject;
+    private Course course;
+    private Course course2;
+    private Waitlist waitlist;
+
+    // Helper method
+    private String generateToken(User user) {
+        return jwtService.generateToken(user);
+    }
+
+    @BeforeEach
+    void setUp() {
+        waitlistRepository.deleteAll();
+        courseRepository.deleteAll();
+        subjectRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Create test users
+        admin = new User("Admin", "User", "admin@example.com", passwordEncoder.encode("adminPass"), Role.ADMIN, 100L);
+        admin = userRepository.save(admin);
+
+        student = new User("Student", "User", "student@example.com", passwordEncoder.encode("studentPass"), Role.STUDENT, 123L);
+        student = userRepository.save(student);
+
+        // Create test subject
+        subject = new Subject("Computer Science", "COSC");
+        subject = subjectRepository.save(subject);
+
+
+         course = new Course(
+            admin,
+            subject,
+            "Introduction to Programming",
+            java.time.LocalDateTime.now().plusDays(1),
+            java.time.LocalDateTime.now().plusMonths(4),
+            50,
+            "101",
+            1,
+            java.time.LocalTime.of(9, 0),
+            java.time.LocalTime.of(10, 30)
+        );
+        course = courseRepository.save(course);
+
+        // Create test course without a waitlist 
+        course2 = new Course( 
+            admin,
+            subject,
+            "Introduction to Programming II",
+            java.time.LocalDateTime.now().plusDays(1),
+            java.time.LocalDateTime.now().plusMonths(4),
+            50,
+            "101",
+            1,
+            java.time.LocalTime.of(9, 0),
+            java.time.LocalTime.of(10, 30)
+        );
+        course2 = courseRepository.save(course2);
+
+        // Create test waitlist
+        waitlist = new Waitlist(course, 10);
+        waitlist = waitlistRepository.save(waitlist);
+    }
+
+    @Test
+    void shouldAllowAdminToCreateWaitlist() throws Exception {
+        WaitlistDto waitlistDto = new WaitlistDto(course2.getId(), 15);
+
+        mockMvc.perform(post("/api/waitlists")
+                .header("Authorization", "Bearer " + generateToken(admin))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(waitlistDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.capacity").value(15))
+                .andExpect(jsonPath("$.course.courseName").value("Introduction to Programming II"));
+    }
+
+    @Test
+    void shouldNotAllowStudentToCreateWaitlist() throws Exception {
+        WaitlistDto waitlistDto = new WaitlistDto(course.getId(), 15);
+
+        mockMvc.perform(post("/api/waitlists")
+                .header("Authorization", "Bearer " + generateToken(student))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(waitlistDto)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldAllowAdminToGetAllWaitlists() throws Exception {
+        mockMvc.perform(get("/api/waitlists")
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].capacity").value(10))
+                .andExpect(jsonPath("$[0].course.courseName").value("Introduction to Programming"));
+    }
+
+    @Test
+    void shouldNotAllowStudentToGetAllWaitlists() throws Exception {
+        mockMvc.perform(get("/api/waitlists")
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldAllowAdminToGetWaitlistById() throws Exception {
+        mockMvc.perform(get("/api/waitlists/" + waitlist.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.capacity").value(10))
+                .andExpect(jsonPath("$.course.courseName").value("Introduction to Programming"));
+    }
+
+    @Test
+    void shouldNotAllowStudentToGetWaitlistById() throws Exception {
+        mockMvc.perform(get("/api/waitlists/" + waitlist.getId())
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldAllowAdminToUpdateWaitlist() throws Exception {
+        WaitlistUpdateDto waitlistUpdateDto = new WaitlistUpdateDto(20);
+
+        mockMvc.perform(put("/api/waitlists/" + waitlist.getId())
+                .header("Authorization", "Bearer " + generateToken(admin))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(waitlistUpdateDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.capacity").value(20));
+    }
+
+    @Test
+    void shouldNotAllowStudentToUpdateWaitlist() throws Exception {
+        WaitlistUpdateDto waitlistUpdateDto = new WaitlistUpdateDto(20);
+
+        mockMvc.perform(put("/api/waitlists/" + waitlist.getId())
+                .header("Authorization", "Bearer " + generateToken(student))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(waitlistUpdateDto)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldAllowAdminToDeleteWaitlist() throws Exception {
+        mockMvc.perform(delete("/api/waitlists/" + waitlist.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void shouldNotAllowStudentToDeleteWaitlist() throws Exception {
+        mockMvc.perform(delete("/api/waitlists/" + waitlist.getId())
+                .header("Authorization", "Bearer " + generateToken(student)))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/Projecta-Backend/src/test/java/com/hackademics/controllerTest/WaitlistEnrollmentControllerTest.java
+++ b/Projecta-Backend/src/test/java/com/hackademics/controllerTest/WaitlistEnrollmentControllerTest.java
@@ -1,0 +1,217 @@
+package com.hackademics.controllerTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackademics.dto.WaitlistEnrollmentDto;
+import com.hackademics.model.Course;
+import com.hackademics.model.Role;
+import com.hackademics.model.Subject;
+import com.hackademics.model.User;
+import com.hackademics.model.Waitlist;
+import com.hackademics.model.WaitlistEnrollment;
+import com.hackademics.repository.CourseRepository;
+import com.hackademics.repository.SubjectRepository;
+import com.hackademics.repository.UserRepository;
+import com.hackademics.repository.WaitlistEnrollmentRepository;
+import com.hackademics.repository.WaitlistRepository;
+import com.hackademics.service.JwtService;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class WaitlistEnrollmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WaitlistEnrollmentRepository waitlistEnrollmentRepository;
+
+    @Autowired
+    private WaitlistRepository waitlistRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private User admin;
+    private User student1;
+    private User student2;
+    private Subject subject;
+    private Course course;
+    private Waitlist waitlist;
+    private WaitlistEnrollment enrollment1;
+
+    // Helper method
+    private String generateToken(User user) {
+        return jwtService.generateToken(user);
+    }
+
+    @BeforeEach
+    void setUp() {
+        waitlistEnrollmentRepository.deleteAll();
+        waitlistRepository.deleteAll();
+        courseRepository.deleteAll();
+        subjectRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Create test users
+        admin = new User("Admin", "User", "admin@example.com", passwordEncoder.encode("adminPass"), Role.ADMIN, 100L);
+        admin = userRepository.save(admin);
+
+        student1 = new User("Student1", "User", "student1@example.com", passwordEncoder.encode("studentPass"), Role.STUDENT, 123L);
+        student1 = userRepository.save(student1);
+
+        student2 = new User("Student2", "User", "student2@example.com", passwordEncoder.encode("studentPass"), Role.STUDENT, 456L);
+        student2 = userRepository.save(student2);
+
+        // Create test subject
+        subject = new Subject("Computer Science", "COSC");
+        subject = subjectRepository.save(subject);
+
+        // Create test course
+        course = new Course(
+            admin,
+            subject,
+            "Introduction to Programming",
+            java.time.LocalDateTime.now().plusDays(1),
+            java.time.LocalDateTime.now().plusMonths(4),
+            50,
+            "101",
+            1,
+            java.time.LocalTime.of(9, 0),
+            java.time.LocalTime.of(10, 30)
+        );
+        course = courseRepository.save(course);
+
+        // Create test waitlist
+        waitlist = new Waitlist(course, 10);
+        waitlist = waitlistRepository.save(waitlist);
+
+        // Create test enrollment only for student1
+        enrollment1 = new WaitlistEnrollment(1, waitlist, student1);
+        enrollment1 = waitlistEnrollmentRepository.save(enrollment1);
+    }
+
+    @Test
+    void shouldAllowAdminToCreateWaitlistEnrollment() throws Exception {
+        WaitlistEnrollmentDto enrollmentDto = new WaitlistEnrollmentDto(waitlist.getId(), student2.getStudentId());
+
+        mockMvc.perform(post("/api/waitlist-enrollments")
+                .header("Authorization", "Bearer " + generateToken(admin))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(enrollmentDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.waitlistPosition").value(2))
+                .andExpect(jsonPath("$.studentSummaryDto.studentId").value(student2.getStudentId()));
+    }
+
+    @Test
+    void shouldAllowStudentToCreateTheirOwnWaitlistEnrollment() throws Exception {
+        WaitlistEnrollmentDto enrollmentDto = new WaitlistEnrollmentDto(waitlist.getId(), student2.getStudentId());
+
+        mockMvc.perform(post("/api/waitlist-enrollments")
+                .header("Authorization", "Bearer " + generateToken(student2))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(enrollmentDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.waitlistPosition").value(2))
+                .andExpect(jsonPath("$.studentSummaryDto.studentId").value(student2.getStudentId()));
+    }
+
+    @Test
+    void shouldNotAllowStudentToCreateWaitlistEnrollmentForAnotherStudent() throws Exception {
+        WaitlistEnrollmentDto enrollmentDto = new WaitlistEnrollmentDto(waitlist.getId(), student2.getStudentId());
+
+        mockMvc.perform(post("/api/waitlist-enrollments")
+                .header("Authorization", "Bearer " + generateToken(student1))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(enrollmentDto)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldAllowAdminToDeleteWaitlistEnrollment() throws Exception {
+        mockMvc.perform(delete("/api/waitlist-enrollments/" + enrollment1.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void shouldAllowStudentToDeleteTheirOwnWaitlistEnrollment() throws Exception {
+        mockMvc.perform(delete("/api/waitlist-enrollments/" + enrollment1.getId())
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void shouldUpdatePositionsWhenDeletingWaitlistEnrollment() throws Exception {
+        // First create an enrollment for student2
+        WaitlistEnrollmentDto enrollmentDto = new WaitlistEnrollmentDto(waitlist.getId(), student2.getStudentId());
+        mockMvc.perform(post("/api/waitlist-enrollments")
+                .header("Authorization", "Bearer " + generateToken(student2))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(enrollmentDto)))
+                .andExpect(status().isCreated());
+
+        // Delete first enrollment
+        mockMvc.perform(delete("/api/waitlist-enrollments/" + enrollment1.getId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isNoContent());
+
+        // Verify that student2's position was updated to 1
+        mockMvc.perform(get("/api/waitlist-enrollments/student/" + student2.getStudentId())
+                .header("Authorization", "Bearer " + generateToken(student2)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].waitlistPosition").value(1));
+    }
+
+    @Test
+    void shouldAllowAdminToGetStudentWaitlistEnrollments() throws Exception {
+        mockMvc.perform(get("/api/waitlist-enrollments/student/" + student1.getStudentId())
+                .header("Authorization", "Bearer " + generateToken(admin)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].studentSummaryDto.studentId").value(student1.getStudentId()));
+    }
+
+    @Test
+    void shouldAllowStudentToGetTheirOwnWaitlistEnrollments() throws Exception {
+        mockMvc.perform(get("/api/waitlist-enrollments/student/" + student1.getStudentId())
+                .header("Authorization", "Bearer " + generateToken(student1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].studentSummaryDto.studentId").value(student1.getStudentId()));
+    }
+}


### PR DESCRIPTION
### Overview

This PR finishes the implementation of Grades, Waitlist, and WaitlistEnrollment controllers. 

- Refactored RBA to service layer only. 
- Utility methods moved to service layer. 
- All endpoints annotated for documentation generation. 
- All endpoints thoroughly tested. 

### Some notes: 

- In an effort to simplify the course/waitlist enrollment implementation for both frontend and backend.... I went this route with the flow of logic / requests: 

1. You request a list of courses from api/courses to display to users for enrollment. 
2. As the backend collects a list of courses, it checks if they are at capacity. 
3. If they **are** at capacity, it checks if they have a waitlist. 
4. If they **have** a waitlist, it sets the `OfferingType` field of the response dto to WAITLIST. 
5. If they **are** at capacity and **do not** have a waitlist, the course is omitted from the list. 
6. If they are **under** capacity, `OfreringType` is set to COURSE. 

If `OfferingType` is WAITLIST, the response dto will always contain waitlist information. 

#### Important: 
If the user tries to register for a course with the COURSE `OfferingType`, you must reach POST at api/enrollment
If the user tries to register for a course with the WAITLIST `OfferingType`, you must read POST at  api/waitlist-enrollments

I believe this is overall the simplest way to handle the 2 types of enrollments, if anyone has any other suggestions, please let me know. 
